### PR TITLE
Add helper for making null-terminated byte arrays

### DIFF
--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -14,6 +14,19 @@ namespace SDL3.Tests
         {
             Console.OutputEncoding = Encoding.UTF8;
 
+            unsafe
+            {
+                // Encoding.UTF8.GetBytes can churn out null pointers and doesn't guarantee null termination
+                fixed (byte* badPointer = Encoding.UTF8.GetBytes(""))
+                    Debug.Assert(badPointer == null);
+
+                fixed (byte* pointer = UTF8GetBytes(""))
+                {
+                    Debug.Assert(pointer != null);
+                    Debug.Assert(pointer[0] == '\0');
+                }
+            }
+
             SDL_SetHint(SDL_HINT_WINDOWS_CLOSE_ON_ALT_F4, "null byte \0 in string"u8);
             Debug.Assert(SDL_GetHint(SDL_HINT_WINDOWS_CLOSE_ON_ALT_F4) == "null byte ");
 

--- a/SDL3-CS/SDL3.cs
+++ b/SDL3-CS/SDL3.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace SDL
 {
@@ -24,6 +26,18 @@ namespace SDL
                 SDL_free(ptr);
 
             return s;
+        }
+
+        /// <summary>
+        /// UTF8 encodes a managed <c>string</c> to a <c>byte</c> array suitable for use in <c>ReadOnlySpan&lt;byte&gt;</c> parameters of SDL functions.
+        /// </summary>
+        /// <param name="s">The <c>string</c> to encode.</param>
+        /// <returns>A null-terminated byte array.</returns>
+        public static byte[] UTF8GetBytes(string s)
+        {
+            byte[] array = Encoding.UTF8.GetBytes(s + '\0');
+            Debug.Assert(array[^1] == '\0');
+            return array;
         }
     }
 }


### PR DESCRIPTION
To be used instead of `Encoding.UTF8.GetBytes()` in osu!framework.