### PR TITLE
Add `Utf8String` helper for safely passing in strings to native methods

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true
 
-[*g.cs]
+[*.g.cs]
 generated_code = true
 
 [*.cs]

--- a/.idea/.idea.SDL3-CS.Desktop/.idea/.gitignore
+++ b/.idea/.idea.SDL3-CS.Desktop/.idea/.gitignore
@@ -1,0 +1,11 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/contentModel.xml
+/.idea.SDL3-CS.Desktop.iml
+/modules.xml
+/projectSettingsUpdater.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.SDL3-CS.Desktop/.idea/.name
+++ b/.idea/.idea.SDL3-CS.Desktop/.idea/.name
@@ -1,0 +1,1 @@
+SDL3-CS.Desktop

--- a/.idea/.idea.SDL3-CS.Desktop/.idea/encodings.xml
+++ b/.idea/.idea.SDL3-CS.Desktop/.idea/encodings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding" addBOMForNewFiles="with BOM under Windows, with no BOM otherwise" />
+</project>

--- a/.idea/.idea.SDL3-CS.Desktop/.idea/indexLayout.xml
+++ b/.idea/.idea.SDL3-CS.Desktop/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/SDL3-CS.SourceGeneration/Changes.cs
+++ b/SDL3-CS.SourceGeneration/Changes.cs
@@ -11,7 +11,7 @@ namespace SDL3.SourceGeneration
         None,
 
         /// <summary>
-        /// Change <c>const char*</c> function parameters to <c>SDLUtf8String</c>.
+        /// Change <c>const char*</c> function parameters to <see cref="Helper.Utf8StringStructName"/>.
         /// </summary>
         ChangeParamsToUtf8String = 1 << 0,
 

--- a/SDL3-CS.SourceGeneration/Changes.cs
+++ b/SDL3-CS.SourceGeneration/Changes.cs
@@ -11,9 +11,9 @@ namespace SDL3.SourceGeneration
         None,
 
         /// <summary>
-        /// Change <c>const char*</c> function parameters to <c>ReadOnlySpan&lt;byte&gt;</c>.
+        /// Change <c>const char*</c> function parameters to <c>SDLUtf8String</c>.
         /// </summary>
-        ChangeParamsToReadOnlySpan = 1 << 0,
+        ChangeParamsToUtf8String = 1 << 0,
 
         /// <summary>
         /// Change <c>char *</c> or <c>const char *</c> return type to <see cref="string"/>.

--- a/SDL3-CS.SourceGeneration/FriendlyOverloadGenerator.cs
+++ b/SDL3-CS.SourceGeneration/FriendlyOverloadGenerator.cs
@@ -112,10 +112,7 @@ using System;
                                              param.Identifier.ValueText + pointer_suffix)
                                          .WithInitializer(
                                              SyntaxFactory.EqualsValueClause(
-                                                 SyntaxFactory.MemberAccessExpression(
-                                                     SyntaxKind.SimpleMemberAccessExpression,
-                                                     SyntaxFactory.IdentifierName(param.Identifier),
-                                                     SyntaxFactory.IdentifierName(Helper.Utf8StringReadOnlySpanFieldName)))))),
+                                                 SyntaxFactory.IdentifierName(param.Identifier))))),
                     expr);
             }
 

--- a/SDL3-CS.SourceGeneration/FriendlyOverloadGenerator.cs
+++ b/SDL3-CS.SourceGeneration/FriendlyOverloadGenerator.cs
@@ -83,8 +83,8 @@ using System;
             {
                 if (param.IsTypeConstCharPtr())
                 {
-                    Debug.Assert(gm.RequiredChanges.HasFlag(Changes.ChangeParamsToReadOnlySpan));
-                    yield return param.WithType(SyntaxFactory.ParseTypeName("ReadOnlySpan<byte>"))
+                    Debug.Assert(gm.RequiredChanges.HasFlag(Changes.ChangeParamsToUtf8String));
+                    yield return param.WithType(SyntaxFactory.ParseTypeName(Helper.Utf8StringStructName))
                                       .WithAttributeLists(SyntaxFactory.List<AttributeListSyntax>());
                 }
                 else
@@ -102,7 +102,7 @@ using System;
 
             foreach (var param in gm.NativeMethod.ParameterList.Parameters.Where(p => p.IsTypeConstCharPtr()).Reverse())
             {
-                Debug.Assert(gm.RequiredChanges.HasFlag(Changes.ChangeParamsToReadOnlySpan));
+                Debug.Assert(gm.RequiredChanges.HasFlag(Changes.ChangeParamsToUtf8String));
 
                 expr = SyntaxFactory.FixedStatement(
                     SyntaxFactory.VariableDeclaration(
@@ -112,7 +112,10 @@ using System;
                                              param.Identifier.ValueText + pointer_suffix)
                                          .WithInitializer(
                                              SyntaxFactory.EqualsValueClause(
-                                                 SyntaxFactory.IdentifierName(param.Identifier))))),
+                                                 SyntaxFactory.MemberAccessExpression(
+                                                     SyntaxKind.SimpleMemberAccessExpression,
+                                                     SyntaxFactory.IdentifierName(param.Identifier),
+                                                     SyntaxFactory.IdentifierName(Helper.Utf8StringReadOnlySpanFieldName)))))),
                     expr);
             }
 
@@ -161,7 +164,7 @@ using System;
             {
                 if (param.IsTypeConstCharPtr())
                 {
-                    Debug.Assert(gm.RequiredChanges.HasFlag(Changes.ChangeParamsToReadOnlySpan));
+                    Debug.Assert(gm.RequiredChanges.HasFlag(Changes.ChangeParamsToUtf8String));
                     yield return SyntaxFactory.Argument(SyntaxFactory.IdentifierName(param.Identifier.ValueText + pointer_suffix));
                 }
                 else

--- a/SDL3-CS.SourceGeneration/Helper.cs
+++ b/SDL3-CS.SourceGeneration/Helper.cs
@@ -16,6 +16,10 @@ namespace SDL3.SourceGeneration
         /// </remarks>
         public const string UnsafePrefix = "Unsafe_";
 
+        public const string Utf8StringStructName = "Utf8String";
+
+        public const string Utf8StringReadOnlySpanFieldName = "Raw";
+
         public static bool IsVoid(this TypeSyntax type) => type is PredefinedTypeSyntax predefined
                                                            && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword);
 

--- a/SDL3-CS.SourceGeneration/Helper.cs
+++ b/SDL3-CS.SourceGeneration/Helper.cs
@@ -18,8 +18,6 @@ namespace SDL3.SourceGeneration
 
         public const string Utf8StringStructName = "Utf8String";
 
-        public const string Utf8StringReadOnlySpanFieldName = "Raw";
-
         public static bool IsVoid(this TypeSyntax type) => type is PredefinedTypeSyntax predefined
                                                            && predefined.Keyword.IsKind(SyntaxKind.VoidKeyword);
 

--- a/SDL3-CS.SourceGeneration/UnfriendlyMethodFinder.cs
+++ b/SDL3-CS.SourceGeneration/UnfriendlyMethodFinder.cs
@@ -42,7 +42,7 @@ namespace SDL3.SourceGeneration
                 foreach (var parameter in method.ParameterList.Parameters)
                 {
                     if (parameter.IsTypeConstCharPtr())
-                        changes |= Changes.ChangeParamsToReadOnlySpan;
+                        changes |= Changes.ChangeParamsToUtf8String;
                 }
 
                 if (changes != Changes.None)

--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -31,6 +31,7 @@ namespace SDL3.Tests
             Debug.Assert(SDL_GetHint(SDL_HINT_WINDOWS_CLOSE_ON_ALT_F4) == "null byte ");
 
             SDL_SetHint(SDL_HINT_WINDOWS_CLOSE_ON_ALT_F4, "1"u8);
+            SDL_SetHint(SDL_HINT_WINDOWS_CLOSE_ON_ALT_F4, "1");
 
             using (var window = new MyWindow())
             {

--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -14,19 +14,6 @@ namespace SDL3.Tests
         {
             Console.OutputEncoding = Encoding.UTF8;
 
-            unsafe
-            {
-                // Encoding.UTF8.GetBytes can churn out null pointers and doesn't guarantee null termination
-                fixed (byte* badPointer = Encoding.UTF8.GetBytes(""))
-                    Debug.Assert(badPointer == null);
-
-                fixed (byte* pointer = UTF8GetBytes(""))
-                {
-                    Debug.Assert(pointer != null);
-                    Debug.Assert(pointer[0] == '\0');
-                }
-            }
-
             SDL_SetHint(SDL_HINT_WINDOWS_CLOSE_ON_ALT_F4, "null byte \0 in string"u8);
             Debug.Assert(SDL_GetHint(SDL_HINT_WINDOWS_CLOSE_ON_ALT_F4) == "null byte ");
 

--- a/SDL3-CS.Tests/SDL3-CS.Tests.csproj
+++ b/SDL3-CS.Tests/SDL3-CS.Tests.csproj
@@ -7,7 +7,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
+
+  <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0"/>
+    <PackageReference Include="NUnit" Version="3.13.3"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\SDL3-CS\SDL3-CS.csproj"/>

--- a/SDL3-CS.Tests/TestUtf8String.cs
+++ b/SDL3-CS.Tests/TestUtf8String.cs
@@ -14,6 +14,7 @@ namespace SDL3.Tests
         {
             checkNull(null);
             checkNull(default);
+            checkNull(new Utf8String()); // don't do this in actual code
         }
 
         [TestCase(null, -1)]

--- a/SDL3-CS.Tests/TestUtf8String.cs
+++ b/SDL3-CS.Tests/TestUtf8String.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using SDL;
+
+namespace SDL3.Tests
+{
+    [TestFixture]
+    public class TestUtf8String
+    {
+        [Test]
+        public void TestNullImplicitConversion()
+        {
+            checkNull(null);
+            checkNull(default);
+        }
+
+        [TestCase(null, -1)]
+        [TestCase("", 1)]
+        [TestCase("\0", 1)]
+        [TestCase("test\0", 5)]
+        [TestCase("test\0test", 10)]
+        [TestCase("test\0test\0", 10)]
+        public static void TestString(string? str, int expectedLength)
+        {
+            if (str == null)
+                checkNull(str);
+            else
+                check(str, expectedLength);
+        }
+
+        [Test]
+        public static void TestNullSpan()
+        {
+            ReadOnlySpan<byte> span = null;
+            checkNull(span);
+        }
+
+        [Test]
+        public static void TestDefaultSpan()
+        {
+            ReadOnlySpan<byte> span = default;
+            checkNull(span);
+        }
+
+        [Test]
+        public static void TestNewSpan()
+        {
+            ReadOnlySpan<byte> span = new ReadOnlySpan<byte>();
+            checkNull(span);
+        }
+
+        [Test]
+        public static void TestReadOnlySpan()
+        {
+            check(""u8, 1);
+            check("\0"u8, 1);
+            check("test"u8, 5);
+            check("test\0"u8, 5);
+            check("test\0test"u8, 10);
+            check("test\0test\0"u8, 10);
+        }
+
+        private static unsafe void checkNull(Utf8String s)
+        {
+            Assert.That(s.Raw == null, "s.Raw == null");
+            Assert.That(s.Raw.Length, Is.EqualTo(0));
+
+            fixed (byte* ptr = s.Raw)
+            {
+                Assert.That(ptr == null, "ptr == null");
+            }
+        }
+
+        private static unsafe void check(Utf8String s, int expectedLength)
+        {
+            Assert.That(s.Raw.Length, Is.EqualTo(expectedLength));
+
+            fixed (byte* ptr = s.Raw)
+            {
+                Assert.That(ptr != null, "ptr != null");
+                Assert.That(ptr[s.Raw.Length - 1], Is.EqualTo(0));
+            }
+        }
+    }
+}

--- a/SDL3-CS.Tests/TestUtf8String.cs
+++ b/SDL3-CS.Tests/TestUtf8String.cs
@@ -69,7 +69,7 @@ namespace SDL3.Tests
             Assert.That(s.Raw == null, "s.Raw == null");
             Assert.That(s.Raw.Length, Is.EqualTo(0));
 
-            fixed (byte* ptr = s.Raw)
+            fixed (byte* ptr = s)
             {
                 Assert.That(ptr == null, "ptr == null");
             }
@@ -79,7 +79,7 @@ namespace SDL3.Tests
         {
             Assert.That(s.Raw.Length, Is.EqualTo(expectedLength));
 
-            fixed (byte* ptr = s.Raw)
+            fixed (byte* ptr = s)
             {
                 Assert.That(ptr != null, "ptr != null");
                 Assert.That(ptr[s.Raw.Length - 1], Is.EqualTo(0));

--- a/SDL3-CS.Tests/TestUtf8String.cs
+++ b/SDL3-CS.Tests/TestUtf8String.cs
@@ -10,7 +10,7 @@ namespace SDL3.Tests
     public class TestUtf8String
     {
         [Test]
-        public void TestNullImplicitConversion()
+        public void TestNoImplicitConversion()
         {
             checkNull(null);
             checkNull(default);

--- a/SDL3-CS.Tests/TestUtf8String.cs
+++ b/SDL3-CS.Tests/TestUtf8String.cs
@@ -19,6 +19,7 @@ namespace SDL3.Tests
         [TestCase(null, -1)]
         [TestCase("", 1)]
         [TestCase("\0", 1)]
+        [TestCase("test", 5)]
         [TestCase("test\0", 5)]
         [TestCase("test\0test", 10)]
         [TestCase("test\0test\0", 10)]

--- a/SDL3-CS/Properties/AssemblyInfo.cs
+++ b/SDL3-CS/Properties/AssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("SDL3-CS.Tests")]

--- a/SDL3-CS/SDL3.cs
+++ b/SDL3-CS/SDL3.cs
@@ -2,9 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace SDL
 {

--- a/SDL3-CS/SDL3.cs
+++ b/SDL3-CS/SDL3.cs
@@ -27,17 +27,5 @@ namespace SDL
 
             return s;
         }
-
-        /// <summary>
-        /// UTF8 encodes a managed <c>string</c> to a <c>byte</c> array suitable for use in <c>ReadOnlySpan&lt;byte&gt;</c> parameters of SDL functions.
-        /// </summary>
-        /// <param name="s">The <c>string</c> to encode.</param>
-        /// <returns>A null-terminated byte array.</returns>
-        public static byte[] UTF8GetBytes(string s)
-        {
-            byte[] array = Encoding.UTF8.GetBytes(s + '\0');
-            Debug.Assert(array[^1] == '\0');
-            return array;
-        }
     }
 }

--- a/SDL3-CS/SDL3/SDL_log.cs
+++ b/SDL3-CS/SDL3/SDL_log.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Runtime.CompilerServices;
-
 namespace SDL
 {
-    public static partial class  SDL3
+    public static partial class SDL3
     {
-        public static  void SDL_LogSetPriority(SDL_LogCategory category, SDL_LogPriority priority) => SDL_LogSetPriority((int)category, priority);
+        public static void SDL_LogSetPriority(SDL_LogCategory category, SDL_LogPriority priority) => SDL_LogSetPriority((int)category, priority);
         public static SDL_LogPriority SDL_LogGetPriority(SDL_LogCategory category) => SDL_LogGetPriority((int)category);
     }
 }

--- a/SDL3-CS/SDL3/SDL_messagebox.cs
+++ b/SDL3-CS/SDL3/SDL_messagebox.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-
 namespace SDL
 {
     public partial struct SDL_MessageBoxButtonData
@@ -18,7 +16,7 @@ namespace SDL
     public static partial class SDL3
     {
         // public static int SDL_ShowSimpleMessageBox([NativeTypeName("Uint32")] uint flags, [NativeTypeName("const char *")] byte* title, [NativeTypeName("const char *")] byte* message, SDL_Window* window);
-        public static unsafe int SDL_ShowSimpleMessageBox(SDL_MessageBoxFlags flags, ReadOnlySpan<byte> title, ReadOnlySpan<byte> message, SDL_Window* window)
+        public static unsafe int SDL_ShowSimpleMessageBox(SDL_MessageBoxFlags flags, Utf8String title, Utf8String message, SDL_Window* window)
             => SDL_ShowSimpleMessageBox((uint)flags, title, message, window);
     }
 }

--- a/SDL3-CS/SDL3/SDL_render.cs
+++ b/SDL3-CS/SDL3/SDL_render.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-
 namespace SDL
 {
     public partial struct SDL_RendererInfo
@@ -12,7 +10,7 @@ namespace SDL
 
     public static partial class SDL3
     {
-        public static unsafe SDL_Renderer* SDL_CreateRenderer(SDL_Window* window, ReadOnlySpan<byte> name, SDL_RendererFlags flags)
+        public static unsafe SDL_Renderer* SDL_CreateRenderer(SDL_Window* window, Utf8String name, SDL_RendererFlags flags)
             => SDL_CreateRenderer(window, name, (uint)flags);
     }
 }

--- a/SDL3-CS/Utf8String.cs
+++ b/SDL3-CS/Utf8String.cs
@@ -13,7 +13,7 @@ namespace SDL
     /// <remarks>Should only be instantiated through implicit conversions.</remarks>
     public readonly ref struct Utf8String
     {
-        public readonly ReadOnlySpan<byte> Raw;
+        internal readonly ReadOnlySpan<byte> Raw;
 
         private Utf8String(ReadOnlySpan<byte> raw)
         {

--- a/SDL3-CS/Utf8String.cs
+++ b/SDL3-CS/Utf8String.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace SDL
@@ -10,7 +9,7 @@ namespace SDL
     /// <summary>
     /// Null pointer or a null-byte terminated UTF8 string suitable for use in native methods.
     /// </summary>
-    /// <remarks>Should only be instantiated through implicit conversions.</remarks>
+    /// <remarks>Should only be instantiated through implicit conversions or with <c>null</c>.</remarks>
     public readonly ref struct Utf8String
     {
         internal readonly ReadOnlySpan<byte> Raw;
@@ -25,11 +24,11 @@ namespace SDL
             if (str == null)
                 return new Utf8String(null);
 
-            return new Utf8String(Encoding.UTF8.GetBytes(ensureTrailingNull(str)));
-        }
+            if (str.EndsWith('\0'))
+                return new Utf8String(Encoding.UTF8.GetBytes(str));
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static string ensureTrailingNull(string str) => str.EndsWith('\0') ? str : str + '\0';
+            return new Utf8String(Encoding.UTF8.GetBytes(str + '\0'));
+        }
 
         public static implicit operator Utf8String(ReadOnlySpan<byte> raw)
         {

--- a/SDL3-CS/Utf8String.cs
+++ b/SDL3-CS/Utf8String.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace SDL
+{
+    /// <summary>
+    /// Null pointer or a null-byte terminated UTF8 string suitable for use in native methods.
+    /// </summary>
+    /// <remarks>Should only be instantiated through implicit conversions.</remarks>
+    public readonly ref struct Utf8String
+    {
+        public readonly ReadOnlySpan<byte> Raw;
+
+        private Utf8String(ReadOnlySpan<byte> raw)
+        {
+            Raw = raw;
+        }
+
+        public static implicit operator Utf8String(string? str)
+        {
+            if (str == null)
+                return new Utf8String(null);
+
+            return new Utf8String(Encoding.UTF8.GetBytes(ensureTrailingNull(str)));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static string ensureTrailingNull(string str) => str.EndsWith('\0') ? str : str + '\0';
+
+        public static implicit operator Utf8String(ReadOnlySpan<byte> raw)
+        {
+            if (raw == null)
+                return new Utf8String(null);
+
+            if (raw.Length == 0)
+                return new Utf8String(new ReadOnlySpan<byte>([0]));
+
+            if (raw[^1] != 0)
+            {
+                byte[] copy = new byte[raw.Length + 1];
+                raw.CopyTo(copy);
+                raw = copy;
+            }
+
+            return new Utf8String(raw);
+        }
+    }
+}

--- a/SDL3-CS/Utf8String.cs
+++ b/SDL3-CS/Utf8String.cs
@@ -48,5 +48,7 @@ namespace SDL
 
             return new Utf8String(raw);
         }
+
+        internal ref readonly byte GetPinnableReference() => ref Raw.GetPinnableReference();
     }
 }


### PR DESCRIPTION
The source generator will now generate `Utf8String` overloads. This overload ensures all strings are properly null-terminated. This is done by copying to a new array and appending a 0 byte if it's not already present.

The overload supports passing in `null` for SDL functions that require null pointers.

Previous sourcegen:

```cs
public static unsafe SDL_bool SDL_SetHint(ReadOnlySpan<byte> name, ReadOnlySpan<byte> value)
{
    fixed (byte* namePtr = name)
    fixed (byte* valuePtr = value)
        return SDL_SetHint(namePtr, valuePtr);
}
```

New sourcegen:

```cs
public static SDL_bool SDL_SetHint(Utf8String name, Utf8String value)
{
    fixed (byte* namePtr = name.Raw)
    fixed (byte* valuePtr = value.Raw)
        return SDL_SetHint(namePtr, valuePtr);
}
```