### PR TITLE
Fix namespaces (from `SDL3` to `SDL`)

### DIFF
--- a/SDL3-CS.Android/SDL3-CS.Android.csproj
+++ b/SDL3-CS.Android/SDL3-CS.Android.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0-android</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
-    <RootNamespace>SDL3.Android</RootNamespace>
+    <RootNamespace>SDL.Android</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/SDL3-CS.SourceGeneration/Changes.cs
+++ b/SDL3-CS.SourceGeneration/Changes.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace SDL3.SourceGeneration
+namespace SDL.SourceGeneration
 {
     [Flags]
     public enum Changes

--- a/SDL3-CS.SourceGeneration/FriendlyOverloadGenerator.cs
+++ b/SDL3-CS.SourceGeneration/FriendlyOverloadGenerator.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SDL3.SourceGeneration
+namespace SDL.SourceGeneration
 {
     [Generator]
     public class FriendlyOverloadGenerator : ISourceGenerator

--- a/SDL3-CS.SourceGeneration/GeneratedMethod.cs
+++ b/SDL3-CS.SourceGeneration/GeneratedMethod.cs
@@ -3,7 +3,7 @@
 
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SDL3.SourceGeneration
+namespace SDL.SourceGeneration
 {
     public record GeneratedMethod
     {

--- a/SDL3-CS.SourceGeneration/Helper.cs
+++ b/SDL3-CS.SourceGeneration/Helper.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SDL3.SourceGeneration
+namespace SDL.SourceGeneration
 {
     public static class Helper
     {

--- a/SDL3-CS.SourceGeneration/SDL3-CS.SourceGeneration.csproj
+++ b/SDL3-CS.SourceGeneration/SDL3-CS.SourceGeneration.csproj
@@ -9,7 +9,7 @@
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsRoslynComponent>true</IsRoslynComponent>
 
-    <RootNamespace>SDL3.SourceGeneration</RootNamespace>
+    <RootNamespace>SDL.SourceGeneration</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SDL3-CS.SourceGeneration/SDL3-CS.SourceGeneration.csproj
+++ b/SDL3-CS.SourceGeneration/SDL3-CS.SourceGeneration.csproj
@@ -10,7 +10,6 @@
     <IsRoslynComponent>true</IsRoslynComponent>
 
     <RootNamespace>SDL3.SourceGeneration</RootNamespace>
-    <PackageId>SDL3.SourceGeneration</PackageId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SDL3-CS.SourceGeneration/UnfriendlyMethodFinder.cs
+++ b/SDL3-CS.SourceGeneration/UnfriendlyMethodFinder.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace SDL3.SourceGeneration
+namespace SDL.SourceGeneration
 {
     public class UnfriendlyMethodFinder : ISyntaxReceiver
     {

--- a/SDL3-CS.Tests/MyWindow.cs
+++ b/SDL3-CS.Tests/MyWindow.cs
@@ -3,10 +3,9 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using SDL;
 using static SDL.SDL3;
 
-namespace SDL3.Tests
+namespace SDL.Tests
 {
     public sealed unsafe class MyWindow : IDisposable
     {

--- a/SDL3-CS.Tests/ObjectHandle.cs
+++ b/SDL3-CS.Tests/ObjectHandle.cs
@@ -5,7 +5,7 @@
 
 using System.Runtime.InteropServices;
 
-namespace SDL3.Tests
+namespace SDL.Tests
 {
     /// <summary>
     /// Wrapper on <see cref="GCHandle" /> that supports the <see cref="IDisposable" /> pattern.

--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -3,10 +3,9 @@
 
 using System.Diagnostics;
 using System.Text;
-using SDL;
 using static SDL.SDL3;
 
-namespace SDL3.Tests
+namespace SDL.Tests
 {
     public static class Program
     {

--- a/SDL3-CS.Tests/SDL3-CS.Tests.csproj
+++ b/SDL3-CS.Tests/SDL3-CS.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <RootNamespace>SDL3.Tests</RootNamespace>
+    <RootNamespace>SDL.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/SDL3-CS.Tests/TestUtf8String.cs
+++ b/SDL3-CS.Tests/TestUtf8String.cs
@@ -2,9 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using SDL;
 
-namespace SDL3.Tests
+namespace SDL.Tests
 {
     [TestFixture]
     public class TestUtf8String


### PR DESCRIPTION
The only real issue with this was Android, as the `SDL3.Android` namespace shadows the `SDL.SDL3` static class.

Noticed when reviewing https://github.com/ppy/osu-framework/pull/6105, as all SDL functions in the android project are specified as `SDL.SDL3.SDL_FunctionName()` instead of `SDL3.SDL_FunctionName()`.
