### PR TITLE
Add string-friendly overload for `SDL_SetClipboardData`

### DIFF
--- a/SDL3-CS.Tests/TestClipboard.cs
+++ b/SDL3-CS.Tests/TestClipboard.cs
@@ -1,0 +1,91 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using NUnit.Framework;
+
+namespace SDL.Tests
+{
+    [TestFixture]
+    public class TestClipboard
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            cleanups = 0;
+            requestedMimeTypes.Clear();
+            SDL3.SDL_Init(SDL_InitFlags.SDL_INIT_VIDEO);
+        }
+
+        [TearDown]
+        public void TearDown() => SDL3.SDL_Quit();
+
+        [Test]
+        public unsafe void TestClipboardData()
+        {
+            int ret = SDL3.SDL_SetClipboardData(&dataCallback, &cleanupCallback, IntPtr.Zero, "test/one", "test/two");
+            Assert.That(ret, Is.EqualTo(0), SDL3.SDL_GetError);
+
+            Assert.That(SDL3.SDL_HasClipboardData("test/one"), Is.EqualTo(SDL_bool.SDL_TRUE));
+            Assert.That(SDL3.SDL_HasClipboardData("test/two"), Is.EqualTo(SDL_bool.SDL_TRUE));
+            Assert.That(SDL3.SDL_HasClipboardData("test/three"), Is.EqualTo(SDL_bool.SDL_FALSE));
+
+            UIntPtr size;
+            IntPtr data = SDL3.SDL_GetClipboardData("test/one", &size);
+
+            try
+            {
+                Assert.That(data, Is.EqualTo(IntPtr.Zero));
+                Assert.That(size, Is.EqualTo(my_length));
+                Assert.That(requestedMimeTypes.Dequeue(), Is.EqualTo("test/one"));
+            }
+            finally
+            {
+                SDL3.SDL_free(data);
+            }
+
+            ret = SDL3.SDL_ClearClipboardData();
+            Assert.That(ret, Is.EqualTo(0), SDL3.SDL_GetError);
+
+            Assert.That(cleanups, Is.EqualTo(1));
+
+            Assert.That(SDL3.SDL_HasClipboardData("test/one"), Is.EqualTo(SDL_bool.SDL_FALSE));
+            Assert.That(SDL3.SDL_HasClipboardData("test/two"), Is.EqualTo(SDL_bool.SDL_FALSE));
+            Assert.That(SDL3.SDL_HasClipboardData("test/three"), Is.EqualTo(SDL_bool.SDL_FALSE));
+
+            data = SDL3.SDL_GetClipboardData("test/two", &size);
+
+            try
+            {
+                Assert.That(data, Is.EqualTo(IntPtr.Zero));
+                Assert.That(size, Is.EqualTo((UIntPtr)0));
+                Assert.That(requestedMimeTypes, Has.Count.EqualTo(0));
+            }
+            finally
+            {
+                SDL3.SDL_free(data);
+            }
+        }
+
+        private static readonly Queue<string?> requestedMimeTypes = [];
+        private static int cleanups;
+
+        private const UIntPtr my_length = 17;
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        private static unsafe IntPtr dataCallback(IntPtr userdata, byte* mimeType, UIntPtr* length)
+        {
+            requestedMimeTypes.Enqueue(SDL3.PtrToStringUTF8(mimeType));
+
+            *length = my_length;
+            return IntPtr.Zero;
+        }
+
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+        private static void cleanupCallback(IntPtr userdata)
+        {
+            cleanups++;
+        }
+    }
+}

--- a/SDL3-CS/SDL3/SDL_clipboard.cs
+++ b/SDL3-CS/SDL3/SDL_clipboard.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace SDL
+{
+    using unsafe SDL_ClipboardDataCallback = delegate* unmanaged[Cdecl]<IntPtr, byte*, UIntPtr*, IntPtr>;
+    using unsafe SDL_ClipboardCleanupCallback = delegate* unmanaged[Cdecl]<IntPtr, void>;
+
+    public partial class SDL3
+    {
+        [LibraryImport("SDL3", StringMarshalling = StringMarshalling.Utf8)]
+        [UnmanagedCallConv(CallConvs = [typeof(CallConvCdecl)])]
+        private static unsafe partial int SDL_SetClipboardData(SDL_ClipboardDataCallback callback, SDL_ClipboardCleanupCallback cleanup, IntPtr userdata, string[] mime_types, UIntPtr num_mime_types);
+
+        public static unsafe int SDL_SetClipboardData(SDL_ClipboardDataCallback callback, SDL_ClipboardCleanupCallback cleanup, IntPtr userdata, params string[] mime_types)
+            => SDL_SetClipboardData(callback, cleanup, userdata, mime_types, (UIntPtr)mime_types.Length);
+    }
+}


### PR DESCRIPTION
To be used when multiple mime types are set on the clipboard.
`string[]` → `byte**` marshalling is horrible to implement manually, so I'm using `LibraryImport`.

The tests don't work out of the box as `SDL3.dll` is not copied... so I've been testing by copying the [desktop-specific includes](https://github.com/ppy/SDL3-CS/blob/8b0479287a9f18b13b74d7820971696b49873360/SDL3-CS.Tests.Desktop/SDL3-CS.Tests.Desktop.csproj#L15-L33) to the base tests project.