### PR TITLE
Update `SDL_WINDOWPOS_*` macro types to SDL_DisplayID

### DIFF
--- a/SDL3-CS/SDL3/SDL_video.cs
+++ b/SDL3-CS/SDL3/SDL_video.cs
@@ -44,13 +44,13 @@ namespace SDL
     public static partial class SDL3
     {
         [Macro]
-        public static int SDL_WINDOWPOS_UNDEFINED_DISPLAY(int X) => (int)(SDL_WINDOWPOS_UNDEFINED_MASK | (X));
+        public static int SDL_WINDOWPOS_UNDEFINED_DISPLAY(SDL_DisplayID X) => (int)(SDL_WINDOWPOS_UNDEFINED_MASK | (uint)X);
 
         [Macro]
         public static bool SDL_WINDOWPOS_ISUNDEFINED(int X) => (((X) & 0xFFFF0000) == SDL_WINDOWPOS_UNDEFINED_MASK);
 
         [Macro]
-        public static int SDL_WINDOWPOS_CENTERED_DISPLAY(int X) => (int)(SDL_WINDOWPOS_CENTERED_MASK | (X));
+        public static int SDL_WINDOWPOS_CENTERED_DISPLAY(SDL_DisplayID X) => (int)(SDL_WINDOWPOS_CENTERED_MASK | (uint)X);
 
         [Macro]
         public static bool SDL_WINDOWPOS_ISCENTERED(int X) => (((X) & 0xFFFF0000) == SDL_WINDOWPOS_CENTERED_MASK);


### PR DESCRIPTION
Noticed when looking at https://wiki.libsdl.org/SDL3/README/migration#sdl_videoh.

> The SDL_WINDOWPOS_UNDEFINED_DISPLAY() and SDL_WINDOWPOS_CENTERED_DISPLAY() macros take a display ID instead of display index. The display ID 0 has a special meaning in this case, and is used to indicate the primary display.