### PR TITLE
Require specifying SDL3 commit to build to prevent incompatible bindings and binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,12 @@
 name: Build Native
 on:
   workflow_dispatch:
-    inputs: {}
+    inputs:
+      sdl_ref:
+        description: SDL3 commit/branch/tag to build
+        required: true
+        default: main
+        type: string
 #  schedule:
 #    - cron: '0 0 * * *'
 env:
@@ -29,7 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'libsdl-org/SDL'
-          ref: 'main'
+          ref: ${{ inputs.sdl_ref }}
 
       - uses: actions/checkout@v4
         with:
@@ -64,7 +69,7 @@ jobs:
           RUNNER_OS: ${{ runner.os }}
           FLAGS: ${{ matrix.platform.flags }}
         run: ./SDL3-CS/build.sh
-      
+
       - name: Get Actions user id
         if: runner.os == 'Linux'
         id: get_uid
@@ -94,7 +99,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'libsdl-org/SDL'
-          ref: 'main'
+          ref: ${{ inputs.sdl_ref }}
 
       - uses: actions/checkout@v4
         with:
@@ -137,7 +142,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'libsdl-org/SDL'
-          ref: 'main'
+          ref: ${{ inputs.sdl_ref }}
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The bindings and binaries of SDL3-CS `2024.518.0` have incompatible differences (some functions have been renamed, see #70).

Since the bindings generator is not fully automated, it's best to manually specify the commit to build.

![image](https://github.com/ppy/SDL3-CS/assets/16479013/42130836-8c9e-400b-ab96-aae5b0f71037)
