### PR TITLE
Enable dynamic support for `libdecor` inside SDL3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,10 +32,12 @@ if [[ $RUNNER_OS == 'Linux' ]]; then
     $SUDO apt-get install -y \
         $GCC \
         $GPP \
+	git \
         cmake \
         ninja-build \
         wayland-scanner++ \
         wayland-protocols \
+	meson \
         pkg-config$TARGET_APT_ARCH \
         libasound2-dev$TARGET_APT_ARCH \
         libdbus-1-dev$TARGET_APT_ARCH \
@@ -43,7 +45,9 @@ if [[ $RUNNER_OS == 'Linux' ]]; then
         libgl1-mesa-dev$TARGET_APT_ARCH \
         libgles2-mesa-dev$TARGET_APT_ARCH \
         libglu1-mesa-dev$TARGET_APT_ARCH \
+	libgtk-3-dev$TARGET_APT_ARCH \
         libibus-1.0-dev$TARGET_APT_ARCH \
+	libpango1.0-dev$TARGET_APT_ARCH \
         libpulse-dev$TARGET_APT_ARCH \
         libsndio-dev$TARGET_APT_ARCH \
         libudev-dev$TARGET_APT_ARCH \
@@ -62,7 +66,23 @@ if [[ $RUNNER_OS == 'Linux' ]]; then
         libdrm-dev$TARGET_APT_ARCH \
         libgbm-dev$TARGET_APT_ARCH \
         libpulse-dev$TARGET_APT_ARCH
+
+    if [[ $TARGET_APT_ARCH != :i386 ]]; then
+        # Build libdecor.
+        # This is required so that window decorations can work on wayland.
+	# The support will only be enabled in SDL, but we're not shipping the libdecor binaries
+	# because making them work from a c# app as everything else does (via runtimes) is too difficult.
+	# Also skip i386 because attempting to support this for i386 is a pain.
+        # Special shoutouts to gnome for refusing to support server-side decorations.
+        git clone https://gitlab.freedesktop.org/libdecor/libdecor.git
+        cd libdecor
+        git checkout 0.2.2
+        meson build --buildtype release
+        $SUDO meson install -C build
+        cd ..
+    fi
 fi
+
 
 cmake -B build $FLAGS -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DSDL_SHARED_ENABLED_BY_DEFAULT=ON -DSDL_STATIC_ENABLED_BY_DEFAULT=ON
 


### PR DESCRIPTION
- Supersedes / closes https://github.com/ppy/SDL2-CS/pull/170
- Addresses https://github.com/ppy/osu/discussions/16693

Done by locally building & installing `libdecor` before building SDL3.

Note that the `libdecor` binaries aren't shipped here, because I can't make them work inside C# apps. It looks like both SDL and `libdecor` do some level of automagic lookup of shared objects; SDL does it to find `libdecor`, and `libdecor` does it to find its "plugins" which are really implementations of the window decoration (if it fails to find any, it just disables itself). The only time I got it working is by force feeding it envvars:

```
OSU_SDL3=1 \
LD_LIBRARY_PATH=bin/Debug/net8.0/runtimes/linux-x64/native \
LIBDECOR_PLUGIN_DIR=bin/Debug/net8.0/runtimes/linux-x64/native/libdecor/plugins-1 \
dotnet run
```

So this is just going to depend on system-ambient `libdecor` to be present, and if there is none, then it'll fail to work. See if I care.

At this point I would like to extend my thanks to the gnome team for wasting a day of my life on all this.

Note that x86 SDL binaries will not have this `libdecor` support enabled, because SDL uses cmake and `libdecor` uses meson, and there is no portable way to tell them both to build a 32-bit binary. Well, that's a half-truth; you can pass CFLAGS to meson via envvars, *but* the install script later will just install the resulting binaries as if they were x64, which leads SDL cmake to not find them, and therefore not enable dynamic `libdecor` support. So let's just not bother.

Only x64 was tested because I don't have an arm device to run linux on.

Evidence that this does anything:
- https://github.com/bdach/SDL3-CS/actions/runs/9192269123/job/25280514593#step:8:1290
- https://github.com/bdach/SDL3-CS/actions/runs/9192269123/job/25280515211#step:7:3461
- https://github.com/bdach/SDL3-CS/actions/runs/9192269123/job/25280515693#step:7:3454

![image](https://github.com/ppy/SDL3-CS/assets/20418176/92eb2561-2a39-4bd4-964e-9cbb641e85ba)

What a sad sight.