### PR TITLE
Pack Android native libs in `ppy.SDL3-CS`

### DIFF
--- a/SDL3-CS.Android/SDL3-CS.Android.csproj
+++ b/SDL3-CS.Android/SDL3-CS.Android.csproj
@@ -22,11 +22,4 @@
   <ItemGroup>
     <EmbeddedJar Include="Jars\SDL3AndroidBridge.jar" />
   </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedNativeLibrary Include="..\native\android\armeabi-v7a\libSDL3.so" />
-    <EmbeddedNativeLibrary Include="..\native\android\arm64-v8a\libSDL3.so" />
-    <EmbeddedNativeLibrary Include="..\native\android\x86\libSDL3.so" />
-    <EmbeddedNativeLibrary Include="..\native\android\x86_64\libSDL3.so" />
-  </ItemGroup>
 </Project>

--- a/SDL3-CS/SDL3-CS.csproj
+++ b/SDL3-CS/SDL3-CS.csproj
@@ -69,6 +69,22 @@
       <PackagePath>runtimes/ios/native</PackagePath>
       <Pack>true</Pack>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3.so">
+      <PackagePath>runtimes/android-arm/native</PackagePath>
+      <Pack>true</Pack>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\libSDL3.so">
+      <PackagePath>runtimes/android-arm64/native</PackagePath>
+      <Pack>true</Pack>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\libSDL3.so">
+      <PackagePath>runtimes/android-x64/native</PackagePath>
+      <Pack>true</Pack>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\native\android\x86\libSDL3.so">
+      <PackagePath>runtimes/android-x86/native</PackagePath>
+      <Pack>true</Pack>
+    </None>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/6299

Fix is implemented as suggested in https://github.com/xamarin/xamarin-android/issues/8794#issuecomment-1984044258.

Tested to work in o!f with a local package release.