### PR TITLE
Fix endianness in SDL_pixel

### DIFF
--- a/SDL3-CS/SDL3/ClangSharp/SDL_pixels.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_pixels.g.cs
@@ -26,7 +26,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using static SDL.SDL_Colorspace;
-using static SDL.SDL_PixelFormat;
 
 namespace SDL
 {
@@ -404,30 +403,6 @@ namespace SDL
 
         [NativeTypeName("#define SDL_ALPHA_TRANSPARENT_FLOAT 0.0f")]
         public const float SDL_ALPHA_TRANSPARENT_FLOAT = 0.0f;
-
-        [NativeTypeName("#define SDL_PIXELFORMAT_RGBA32 SDL_PIXELFORMAT_ABGR8888")]
-        public const SDL_PixelFormat SDL_PIXELFORMAT_RGBA32 = SDL_PIXELFORMAT_ABGR8888;
-
-        [NativeTypeName("#define SDL_PIXELFORMAT_ARGB32 SDL_PIXELFORMAT_BGRA8888")]
-        public const SDL_PixelFormat SDL_PIXELFORMAT_ARGB32 = SDL_PIXELFORMAT_BGRA8888;
-
-        [NativeTypeName("#define SDL_PIXELFORMAT_BGRA32 SDL_PIXELFORMAT_ARGB8888")]
-        public const SDL_PixelFormat SDL_PIXELFORMAT_BGRA32 = SDL_PIXELFORMAT_ARGB8888;
-
-        [NativeTypeName("#define SDL_PIXELFORMAT_ABGR32 SDL_PIXELFORMAT_RGBA8888")]
-        public const SDL_PixelFormat SDL_PIXELFORMAT_ABGR32 = SDL_PIXELFORMAT_RGBA8888;
-
-        [NativeTypeName("#define SDL_PIXELFORMAT_RGBX32 SDL_PIXELFORMAT_XBGR8888")]
-        public const SDL_PixelFormat SDL_PIXELFORMAT_RGBX32 = SDL_PIXELFORMAT_XBGR8888;
-
-        [NativeTypeName("#define SDL_PIXELFORMAT_XRGB32 SDL_PIXELFORMAT_BGRX8888")]
-        public const SDL_PixelFormat SDL_PIXELFORMAT_XRGB32 = SDL_PIXELFORMAT_BGRX8888;
-
-        [NativeTypeName("#define SDL_PIXELFORMAT_BGRX32 SDL_PIXELFORMAT_XRGB8888")]
-        public const SDL_PixelFormat SDL_PIXELFORMAT_BGRX32 = SDL_PIXELFORMAT_XRGB8888;
-
-        [NativeTypeName("#define SDL_PIXELFORMAT_XBGR32 SDL_PIXELFORMAT_RGBX8888")]
-        public const SDL_PixelFormat SDL_PIXELFORMAT_XBGR32 = SDL_PIXELFORMAT_RGBX8888;
 
         [NativeTypeName("#define SDL_COLORSPACE_RGB_DEFAULT SDL_COLORSPACE_SRGB")]
         public const SDL_Colorspace SDL_COLORSPACE_RGB_DEFAULT = SDL_COLORSPACE_SRGB;

--- a/SDL3-CS/SDL3/SDL_pixels.cs
+++ b/SDL3-CS/SDL3/SDL_pixels.cs
@@ -133,5 +133,29 @@ namespace SDL
 
         [Macro]
         public static bool SDL_ISCOLORSPACE_FULL_RANGE(SDL_Colorspace X) => (SDL_COLORSPACERANGE(X) == SDL_COLOR_RANGE_FULL);
+
+        [Constant]
+        public static readonly SDL_PixelFormat SDL_PIXELFORMAT_RGBA32 = BitConverter.IsLittleEndian ? SDL_PIXELFORMAT_ABGR8888 : SDL_PIXELFORMAT_RGBA8888;
+
+        [Constant]
+        public static readonly SDL_PixelFormat SDL_PIXELFORMAT_ARGB32 = BitConverter.IsLittleEndian ? SDL_PIXELFORMAT_BGRA8888 : SDL_PIXELFORMAT_ARGB8888;
+
+        [Constant]
+        public static readonly SDL_PixelFormat SDL_PIXELFORMAT_BGRA32 = BitConverter.IsLittleEndian ? SDL_PIXELFORMAT_ARGB8888 : SDL_PIXELFORMAT_BGRA8888;
+
+        [Constant]
+        public static readonly SDL_PixelFormat SDL_PIXELFORMAT_ABGR32 = BitConverter.IsLittleEndian ? SDL_PIXELFORMAT_RGBA8888 : SDL_PIXELFORMAT_ABGR8888;
+
+        [Constant]
+        public static readonly SDL_PixelFormat SDL_PIXELFORMAT_RGBX32 = BitConverter.IsLittleEndian ? SDL_PIXELFORMAT_XBGR8888 : SDL_PIXELFORMAT_RGBX8888;
+
+        [Constant]
+        public static readonly SDL_PixelFormat SDL_PIXELFORMAT_XRGB32 = BitConverter.IsLittleEndian ? SDL_PIXELFORMAT_BGRX8888 : SDL_PIXELFORMAT_XRGB8888;
+
+        [Constant]
+        public static readonly SDL_PixelFormat SDL_PIXELFORMAT_BGRX32 = BitConverter.IsLittleEndian ? SDL_PIXELFORMAT_XRGB8888 : SDL_PIXELFORMAT_BGRX8888;
+
+        [Constant]
+        public static readonly SDL_PixelFormat SDL_PIXELFORMAT_XBGR32 = BitConverter.IsLittleEndian ? SDL_PIXELFORMAT_RGBX8888 : SDL_PIXELFORMAT_XBGR8888;
     }
 }


### PR DESCRIPTION
This change is from #146. I noticed it while updating bindings, but I closed it so here is another separate PR.

https://github.com/libsdl-org/SDL/blob/main/include/SDL3/SDL_pixels.h#L397