### PR TITLE
Submit binary file updates as a single PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,15 +70,15 @@ jobs:
         with:
           user_id: ${{ steps.get_uid.outputs.uid }}
 
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
+      - name: Compress native directory
+        run: tar -cf native-${{ matrix.platform.name }}.tar native
+
+      - name: Upload native artifact
+        uses: actions/upload-artifact@v4
         with:
-          commit-message: Update ${{ matrix.platform.name }} SDL binaries
-          title: Update ${{ matrix.platform.name }} SDL binaries
-          body: This PR has been auto-generated to update the ${{ matrix.platform.name }} SDL binaries.
-          branch: update-${{ matrix.platform.name }}-binaries
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+          name: native-${{ matrix.platform.name }}
+          path: native-${{ matrix.platform.name }}.tar
+          if-no-files-found: error
 
   build-ios:
     name: ios
@@ -104,15 +104,15 @@ jobs:
           cp External/SDL/Xcode/SDL/build/SDL3.xcframework/ios-arm64_x86_64-simulator/SDL3.framework/SDL3       native/ios/SDL3.xcframework/ios-arm64_x86_64-simulator/SDL3.framework/SDL3;
           cp External/SDL/Xcode/SDL/build/SDL3.xcframework/ios-arm64_x86_64-simulator/SDL3.framework/Info.plist native/ios/SDL3.xcframework/ios-arm64_x86_64-simulator/SDL3.framework/Info.plist;
 
-      - name: Create pull request
-        uses: peter-evans/create-pull-request@v6
+      - name: Compress native directory
+        run: tar -cf native-ios.tar native
+
+      - name: Upload native artifact
+        uses: actions/upload-artifact@v4
         with:
-          commit-message: Update iOS SDL binaries
-          title: Update iOS SDL binaries
-          body: This PR has been auto-generated to update the iOS SDL binaries
-          branch: update-ios-binaries
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
+          name: native-ios
+          path: native-ios.tar
+          if-no-files-found: error
 
   build-android:
     name: android
@@ -165,12 +165,58 @@ jobs:
           javac -cp $ANDROID_HOME/platforms/$PLATFORM_VER/android.jar -encoding utf8 org/libsdl/app/*.java
           jar cvf $OUTPUT/SDL3AndroidBridge.jar org/libsdl/app/*.class
 
+      - name: Compress native directory
+        run: tar -cf native-android.tar native
+
+      - name: Upload native artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-android
+          path: native-android.tar
+          if-no-files-found: error
+
+      - name: Upload JAR artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-jar
+          path: SDL3-CS.Android/Jars/SDL3AndroidBridge.jar
+          if-no-files-found: error
+
+  make-pr:
+    name: Submit pull request
+    runs-on: ubuntu-latest
+    needs: [ build, build-ios, build-android ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Download native artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: native-*
+          merge-multiple: true
+
+      - name: Decompress native artifacts
+        run: |
+          for file in native-*.tar
+          do
+            tar -xf "$file"
+          done
+          rm native-*.tar
+
+      - name: Download JAR artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: android-jar
+          path: SDL3-CS.Android/Jars/
+
       - name: Create pull request
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: Update Android SDL binaries
-          title: Update Android SDL binaries
-          body: This PR has been auto-generated to update the Android SDL binaries
-          branch: update-android-binaries
+          commit-message: Update native binaries
+          title: Update native binaries
+          body: This PR has been auto-generated to update the native SDL binaries
+          branch: update-native-binaries
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
           user_id: ${{ steps.get_uid.outputs.uid }}
 
       - name: Compress native directory
-        run: tar -cf native-${{ matrix.platform.name }}.tar native
+        run: tar -cf native-${{ matrix.platform.name }}.tar native/${{ matrix.platform.name }}
 
       - name: Upload native artifact
         uses: actions/upload-artifact@v4
@@ -105,7 +105,7 @@ jobs:
           cp External/SDL/Xcode/SDL/build/SDL3.xcframework/ios-arm64_x86_64-simulator/SDL3.framework/Info.plist native/ios/SDL3.xcframework/ios-arm64_x86_64-simulator/SDL3.framework/Info.plist;
 
       - name: Compress native directory
-        run: tar -cf native-ios.tar native
+        run: tar -cf native-ios.tar native/ios
 
       - name: Upload native artifact
         uses: actions/upload-artifact@v4
@@ -166,7 +166,7 @@ jobs:
           jar cvf $OUTPUT/SDL3AndroidBridge.jar org/libsdl/app/*.class
 
       - name: Compress native directory
-        run: tar -cf native-android.tar native
+        run: tar -cf native-android.tar native/android
 
       - name: Upload native artifact
         uses: actions/upload-artifact@v4
@@ -188,8 +188,6 @@ jobs:
     needs: [ build, build-ios, build-android ]
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Download native artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Super spammy + manual merge process.

The `native` dir is compressed as a `tar` to not deal with RIDs and decompressed into the repository root. Android JAR is uploaded as-is because it's a single file.

Run: https://github.com/smoogipoo/SDL3-CS/actions/runs/11049385220
PR: https://github.com/smoogipoo/SDL3-CS/pull/49