### PR TITLE
Bump actions/setup-java to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
           submodules: true
 
       - name: Setup JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: microsoft
           java-version: |


### PR DESCRIPTION
Fixes this warning when running the build-native workflow. Example run [with warning](https://github.com/ppy/SDL3-CS/actions/runs/11136793472/job/30949156640), and [without](https://github.com/Susko3/SDL3-CS/actions/runs/11147227112/job/30981029694).

![image](https://github.com/user-attachments/assets/682eff35-44a3-4ced-883f-24d1f45f1afc)
