### PR TITLE
Update bindings

### DIFF
--- a/SDL3-CS/SDL3/ClangSharp/SDL_error.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_error.g.cs
@@ -35,6 +35,10 @@ namespace SDL
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
+        public static extern SDLBool SDL_SetErrorV([NativeTypeName("const char *")] byte* fmt, [NativeTypeName("va_list")] byte* ap);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("bool")]
         public static extern SDLBool SDL_OutOfMemory();
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GetError", ExactSpelling = true)]

--- a/SDL3-CS/SDL3/ClangSharp/SDL_events.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_events.g.cs
@@ -871,7 +871,7 @@ namespace SDL
         public byte* data;
     }
 
-    public partial struct SDL_ClipboardEvent
+    public unsafe partial struct SDL_ClipboardEvent
     {
         public SDL_EventType type;
 
@@ -880,6 +880,15 @@ namespace SDL
 
         [NativeTypeName("Uint64")]
         public ulong timestamp;
+
+        [NativeTypeName("bool")]
+        public SDLBool owner;
+
+        [NativeTypeName("Sint32")]
+        public int n_mime_types;
+
+        [NativeTypeName("const char **")]
+        public byte** mime_types;
     }
 
     public partial struct SDL_SensorEvent

--- a/SDL3-CS/SDL3/ClangSharp/SDL_gpu.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_gpu.g.cs
@@ -175,6 +175,48 @@ namespace SDL
         SDL_GPU_TEXTUREFORMAT_D32_FLOAT,
         SDL_GPU_TEXTUREFORMAT_D24_UNORM_S8_UINT,
         SDL_GPU_TEXTUREFORMAT_D32_FLOAT_S8_UINT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_4x4_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_5x4_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_5x5_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_6x5_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_6x6_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_8x5_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_8x6_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_8x8_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x5_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x6_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x8_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x10_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_12x10_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_12x12_UNORM,
+        SDL_GPU_TEXTUREFORMAT_ASTC_4x4_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_5x4_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_5x5_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_6x5_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_6x6_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_8x5_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_8x6_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_8x8_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x5_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x6_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x8_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x10_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_12x10_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_12x12_UNORM_SRGB,
+        SDL_GPU_TEXTUREFORMAT_ASTC_4x4_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_5x4_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_5x5_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_6x5_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_6x6_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_8x5_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_8x6_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_8x8_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x5_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x6_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x8_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_10x10_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_12x10_FLOAT,
+        SDL_GPU_TEXTUREFORMAT_ASTC_12x12_FLOAT,
     }
 
     public enum SDL_GPUTextureType
@@ -653,10 +695,10 @@ namespace SDL
         public SDLBool enable_color_write_mask;
 
         [NativeTypeName("Uint8")]
-        public byte padding2;
+        public byte padding1;
 
         [NativeTypeName("Uint8")]
-        public byte padding3;
+        public byte padding2;
     }
 
     public unsafe partial struct SDL_GPUShaderCreateInfo
@@ -1333,6 +1375,10 @@ namespace SDL
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
         public static extern SDLBool SDL_GPUTextureSupportsSampleCount(SDL_GPUDevice* device, SDL_GPUTextureFormat format, SDL_GPUSampleCount sample_count);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("Uint32")]
+        public static extern uint SDL_CalculateGPUTextureFormatSize(SDL_GPUTextureFormat format, [NativeTypeName("Uint32")] uint width, [NativeTypeName("Uint32")] uint height, [NativeTypeName("Uint32")] uint depth_or_layer_count);
 
         [NativeTypeName("#define SDL_GPU_TEXTUREUSAGE_SAMPLER (1u << 0)")]
         public const uint SDL_GPU_TEXTUREUSAGE_SAMPLER = (1U << 0);

--- a/SDL3-CS/SDL3/ClangSharp/SDL_hints.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_hints.g.cs
@@ -442,6 +442,9 @@ namespace SDL
         [NativeTypeName("#define SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH \"SDL_MAC_OPENGL_ASYNC_DISPATCH\"")]
         public static ReadOnlySpan<byte> SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH => "SDL_MAC_OPENGL_ASYNC_DISPATCH"u8;
 
+        [NativeTypeName("#define SDL_HINT_MAC_SCROLL_MOMENTUM \"SDL_MAC_SCROLL_MOMENTUM\"")]
+        public static ReadOnlySpan<byte> SDL_HINT_MAC_SCROLL_MOMENTUM => "SDL_MAC_SCROLL_MOMENTUM"u8;
+
         [NativeTypeName("#define SDL_HINT_MAIN_CALLBACK_RATE \"SDL_MAIN_CALLBACK_RATE\"")]
         public static ReadOnlySpan<byte> SDL_HINT_MAIN_CALLBACK_RATE => "SDL_MAIN_CALLBACK_RATE"u8;
 

--- a/SDL3-CS/SDL3/ClangSharp/SDL_iostream.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_iostream.g.cs
@@ -264,6 +264,12 @@ namespace SDL
         [NativeTypeName("#define SDL_PROP_IOSTREAM_ANDROID_AASSET_POINTER \"SDL.iostream.android.aasset\"")]
         public static ReadOnlySpan<byte> SDL_PROP_IOSTREAM_ANDROID_AASSET_POINTER => "SDL.iostream.android.aasset"u8;
 
+        [NativeTypeName("#define SDL_PROP_IOSTREAM_MEMORY_POINTER \"SDL.iostream.memory.base\"")]
+        public static ReadOnlySpan<byte> SDL_PROP_IOSTREAM_MEMORY_POINTER => "SDL.iostream.memory.base"u8;
+
+        [NativeTypeName("#define SDL_PROP_IOSTREAM_MEMORY_SIZE_NUMBER \"SDL.iostream.memory.size\"")]
+        public static ReadOnlySpan<byte> SDL_PROP_IOSTREAM_MEMORY_SIZE_NUMBER => "SDL.iostream.memory.size"u8;
+
         [NativeTypeName("#define SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER \"SDL.iostream.dynamic.memory\"")]
         public static ReadOnlySpan<byte> SDL_PROP_IOSTREAM_DYNAMIC_MEMORY_POINTER => "SDL.iostream.dynamic.memory"u8;
 

--- a/SDL3-CS/SDL3/ClangSharp/SDL_joystick.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_joystick.g.cs
@@ -380,9 +380,6 @@ namespace SDL
         [NativeTypeName("#define SDL_JOYSTICK_AXIS_MIN -32768")]
         public const int SDL_JOYSTICK_AXIS_MIN = -32768;
 
-        [NativeTypeName("#define SDL_IPHONE_MAX_GFORCE 5.0")]
-        public const double SDL_IPHONE_MAX_GFORCE = 5.0;
-
         [NativeTypeName("#define SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN \"SDL.joystick.cap.mono_led\"")]
         public static ReadOnlySpan<byte> SDL_PROP_JOYSTICK_CAP_MONO_LED_BOOLEAN => "SDL.joystick.cap.mono_led"u8;
 

--- a/SDL3-CS/SDL3/ClangSharp/SDL_log.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_log.g.cs
@@ -114,6 +114,10 @@ namespace SDL
         public static extern void SDL_LogMessageV(int category, SDL_LogPriority priority, [NativeTypeName("const char *")] byte* fmt, [NativeTypeName("va_list")] byte* ap);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("SDL_LogOutputFunction")]
+        public static extern delegate* unmanaged[Cdecl]<IntPtr, int, SDL_LogPriority, byte*, void> SDL_GetDefaultLogOutputFunction();
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void SDL_GetLogOutputFunction([NativeTypeName("SDL_LogOutputFunction *")] delegate* unmanaged[Cdecl]<IntPtr, int, SDL_LogPriority, byte*, void>* callback, [NativeTypeName("void **")] IntPtr* userdata);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/SDL3-CS/SDL3/ClangSharp/SDL_mouse.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_mouse.g.cs
@@ -155,19 +155,19 @@ namespace SDL
         [NativeTypeName("#define SDL_BUTTON_X2 5")]
         public const int SDL_BUTTON_X2 = 5;
 
-        [NativeTypeName("#define SDL_BUTTON_LMASK SDL_BUTTON(SDL_BUTTON_LEFT)")]
+        [NativeTypeName("#define SDL_BUTTON_LMASK SDL_BUTTON_MASK(SDL_BUTTON_LEFT)")]
         public const uint SDL_BUTTON_LMASK = (1U << ((1) - 1));
 
-        [NativeTypeName("#define SDL_BUTTON_MMASK SDL_BUTTON(SDL_BUTTON_MIDDLE)")]
+        [NativeTypeName("#define SDL_BUTTON_MMASK SDL_BUTTON_MASK(SDL_BUTTON_MIDDLE)")]
         public const uint SDL_BUTTON_MMASK = (1U << ((2) - 1));
 
-        [NativeTypeName("#define SDL_BUTTON_RMASK SDL_BUTTON(SDL_BUTTON_RIGHT)")]
+        [NativeTypeName("#define SDL_BUTTON_RMASK SDL_BUTTON_MASK(SDL_BUTTON_RIGHT)")]
         public const uint SDL_BUTTON_RMASK = (1U << ((3) - 1));
 
-        [NativeTypeName("#define SDL_BUTTON_X1MASK SDL_BUTTON(SDL_BUTTON_X1)")]
+        [NativeTypeName("#define SDL_BUTTON_X1MASK SDL_BUTTON_MASK(SDL_BUTTON_X1)")]
         public const uint SDL_BUTTON_X1MASK = (1U << ((4) - 1));
 
-        [NativeTypeName("#define SDL_BUTTON_X2MASK SDL_BUTTON(SDL_BUTTON_X2)")]
+        [NativeTypeName("#define SDL_BUTTON_X2MASK SDL_BUTTON_MASK(SDL_BUTTON_X2)")]
         public const uint SDL_BUTTON_X2MASK = (1U << ((5) - 1));
     }
 }

--- a/SDL3-CS/SDL3/ClangSharp/SDL_render.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_render.g.cs
@@ -342,7 +342,7 @@ namespace SDL
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
-        public static extern SDLBool SDL_RenderTextureRotated(SDL_Renderer* renderer, SDL_Texture* texture, [NativeTypeName("const SDL_FRect *")] SDL_FRect* srcrect, [NativeTypeName("const SDL_FRect *")] SDL_FRect* dstrect, [NativeTypeName("const double")] double angle, [NativeTypeName("const SDL_FPoint *")] SDL_FPoint* center, [NativeTypeName("const SDL_FlipMode")] SDL_FlipMode flip);
+        public static extern SDLBool SDL_RenderTextureRotated(SDL_Renderer* renderer, SDL_Texture* texture, [NativeTypeName("const SDL_FRect *")] SDL_FRect* srcrect, [NativeTypeName("const SDL_FRect *")] SDL_FRect* dstrect, double angle, [NativeTypeName("const SDL_FPoint *")] SDL_FPoint* center, SDL_FlipMode flip);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]

--- a/SDL3-CS/SDL3/ClangSharp/SDL_stdinc.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_stdinc.g.cs
@@ -401,6 +401,10 @@ namespace SDL
         [return: NativeTypeName("Uint32")]
         public static extern uint SDL_StepUTF8([NativeTypeName("const char **")] byte** pstr, [NativeTypeName("size_t *")] nuint* pslen);
 
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("Uint32")]
+        public static extern uint SDL_StepBackUTF8([NativeTypeName("const char *")] byte* start, [NativeTypeName("const char **")] byte** pstr);
+
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_UCS4ToUTF8", ExactSpelling = true)]
         [return: NativeTypeName("char *")]
         public static extern byte* Unsafe_SDL_UCS4ToUTF8([NativeTypeName("Uint32")] uint codepoint, [NativeTypeName("char *")] byte* dst);

--- a/SDL3-CS/SDL3/ClangSharp/SDL_thread.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_thread.g.cs
@@ -60,7 +60,7 @@ namespace SDL
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
-        public static extern SDLBool SDL_SetThreadPriority(SDL_ThreadPriority priority);
+        public static extern SDLBool SDL_SetCurrentThreadPriority(SDL_ThreadPriority priority);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void SDL_WaitThread(SDL_Thread* thread, int* status);

--- a/SDL3-CS/SDL3/ClangSharp/SDL_timer.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_timer.g.cs
@@ -53,6 +53,9 @@ namespace SDL
         public static extern void SDL_DelayNS([NativeTypeName("Uint64")] ulong ns);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern void SDL_DelayPrecise([NativeTypeName("Uint64")] ulong ns);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern SDL_TimerID SDL_AddTimer([NativeTypeName("Uint32")] uint interval, [NativeTypeName("SDL_TimerCallback")] delegate* unmanaged[Cdecl]<IntPtr, SDL_TimerID, uint, uint> callback, [NativeTypeName("void*")] IntPtr userdata);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/SDL3-CS/SDL3/ClangSharp/SDL_version.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_version.g.cs
@@ -42,7 +42,7 @@ namespace SDL
         [NativeTypeName("#define SDL_MINOR_VERSION 1")]
         public const int SDL_MINOR_VERSION = 1;
 
-        [NativeTypeName("#define SDL_MICRO_VERSION 2")]
-        public const int SDL_MICRO_VERSION = 2;
+        [NativeTypeName("#define SDL_MICRO_VERSION 5")]
+        public const int SDL_MICRO_VERSION = 5;
     }
 }

--- a/SDL3-CS/SDL3/ClangSharp/SDL_video.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_video.g.cs
@@ -545,7 +545,7 @@ namespace SDL
         public static extern IntPtr SDL_EGL_GetWindowSurface(SDL_Window* window);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        public static extern void SDL_EGL_SetAttributeCallbacks([NativeTypeName("SDL_EGLAttribArrayCallback")] delegate* unmanaged[Cdecl]<IntPtr, nint*> platformAttribCallback, [NativeTypeName("SDL_EGLIntArrayCallback")] delegate* unmanaged[Cdecl]<IntPtr, int*> surfaceAttribCallback, [NativeTypeName("SDL_EGLIntArrayCallback")] delegate* unmanaged[Cdecl]<IntPtr, int*> contextAttribCallback, [NativeTypeName("void*")] IntPtr userdata);
+        public static extern void SDL_EGL_SetAttributeCallbacks([NativeTypeName("SDL_EGLAttribArrayCallback")] delegate* unmanaged[Cdecl]<IntPtr, nint*> platformAttribCallback, [NativeTypeName("SDL_EGLIntArrayCallback")] delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, int*> surfaceAttribCallback, [NativeTypeName("SDL_EGLIntArrayCallback")] delegate* unmanaged[Cdecl]<IntPtr, IntPtr, IntPtr, int*> contextAttribCallback, [NativeTypeName("void*")] IntPtr userdata);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]


### PR DESCRIPTION
This PR updates bindings, mainly to make https://github.com/libsdl-org/SDL/commit/c8f5f6d47a2036df4a5966e65021957154ee55d4 available for osu!framework.

`SDL_DelayNS` now uses OS-native high-resolution delay functions instead of busy loop with the change, and it seems to greatly improve frame pacing on Linux, and probably on all platforms except for Windows where high-resolution timer has already been in use.

It was brought to attention thanks to @harrislegobrick. Their PR for framework will follow up once SDL3-CS gets updated. You can try it by using [this diff](https://gist.github.com/hwsmm/75bd5ce242a74e808c057aac29ed91ce) on top of my framework branch for now.

However, SDL_DelayNS may require SDL3 initialization in some platforms, and we are not using SDL3 as default at the moment. We probably want to avoid adding more unsafe code to directly implement this in framework, so I guess we may need a condition to only use SDL_DelayNS if SDL3 is being used.

---

[Relevant framework branch](https://github.com/hwsmm/osu-framework/tree/sdl3-bindings-update), SDLBool made code look a lot cleaner!