### PR TITLE
Update SDL to pull in android enter key fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
           - { name: win-arm64,   os: windows-latest, flags: -A ARM64 }
           - { name: linux-x64,   os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":amd64" }
           - { name: linux-x86,   os: ubuntu-20.04,   flags: -GNinja -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32", target_apt_arch: ":i386" }
-          - { name: linux-arm64, os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":arm64", container: arm64v8/ubuntu }
-          - { name: linux-arm,   os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":armhf", container: arm32v7/ubuntu }
+          - { name: linux-arm64, os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":arm64", container: arm64v8/ubuntu, docker_platform: linux/arm64/v8 }
+          - { name: linux-arm,   os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":armhf", container: arm32v7/ubuntu, docker_platform: linux/arm/v7 }
           - { name: osx-x64,     os: macos-latest,   flags: -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 }
           # NOTE: macOS 11.0 is the first released supported by Apple Silicon.
           - { name: osx-arm64,   os: macos-latest,   flags: -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 }
@@ -45,6 +45,7 @@ jobs:
             -e RUNNER_OS=${{ runner.os }}
             -e FLAGS=${{ matrix.platform.flags }}
             -e BUILD_TYPE=${{ env.BUILD_TYPE }}
+            --platform ${{ matrix.platform.docker_platform }}
           run: |
             cd /workspace
             ./External/build.sh


### PR DESCRIPTION
## [Update SDL submodule](https://github.com/ppy/SDL3-CS/commit/84c8d4240fd02320df0aa9bf700d1b96acd0d14e)

Pulls in https://github.com/libsdl-org/SDL/pull/11256 to fix https://github.com/ppy/osu/issues/28966.

## [Fix linux-arm build failures due to docker changes](https://github.com/ppy/SDL3-CS/commit/53dff157d59ae43cd6c339dc8352714dca37ce50)

`linux-arm(64)` builds [started failing](https://github.com/bdach/SDL3-CS/actions/runs/11440882162/job/31827702325) with

    latest: Pulling from arm64v8/ubuntu
    docker: no matching manifest for linux/amd64 in the manifest list entries.

Upon closer inspection, new `arm32v7/ubuntu` and `arm64v8/ubuntu` images were pushed on Oct 19, 2024, which seemed related.

While pinning the images to the last known working digest worked, it's obviously suboptimal. Looking closer at previous passing build logs, warnings are noticeable:

    WARNING: The requested image's platform (linux/arm/v7) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested

    WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested

therefore I decided to try specifying the platform explicitly to see if it fixes the issue, and it does.

---

Native build workflow run result available for preview at https://github.com/bdach/SDL3-CS/actions/runs/11455020110.

Binaries available for testing at https://github.com/bdach/SDL3-CS/pull/19.