### PR TITLE
Specify Android ABIs as command line params to SDL `androidbuildlibs.sh`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,8 +151,7 @@ jobs:
           rm -rf $OUTPUT && mkdir -p $OUTPUT
 
           # Build SDL3
-          sed -i 's/abi=.*/abi="armeabi-v7a arm64-v8a x86 x86_64"/g' ./External/SDL/build-scripts/androidbuildlibs.sh
-          ./External/SDL/build-scripts/androidbuildlibs.sh NDK_LIBS_OUT="$OUTPUT"
+          ./External/SDL/build-scripts/androidbuildlibs.sh APP_ABI="armeabi-v7a arm64-v8a x86 x86_64" NDK_LIBS_OUT="$OUTPUT"
 
       - name: Build SDL3 Android Java
         run: |


### PR DESCRIPTION
Removes the `sed` hack that was used previously.

Successful run: https://github.com/Susko3/SDL3-CS/actions/runs/11583022293/job/32247299118#step:6:215