### PR TITLE
Update bindings, including manual macro update

### DIFF
--- a/SDL3-CS/SDL3/ClangSharp/SDL_gpu.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_gpu.g.cs
@@ -1351,6 +1351,10 @@ namespace SDL
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
+        public static extern SDLBool SDL_CancelGPUCommandBuffer(SDL_GPUCommandBuffer* command_buffer);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("bool")]
         public static extern SDLBool SDL_WaitForGPUIdle(SDL_GPUDevice* device);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/SDL3-CS/SDL3/ClangSharp/SDL_hints.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_hints.g.cs
@@ -76,6 +76,9 @@ namespace SDL
         [NativeTypeName("#define SDL_HINT_ANDROID_BLOCK_ON_PAUSE \"SDL_ANDROID_BLOCK_ON_PAUSE\"")]
         public static ReadOnlySpan<byte> SDL_HINT_ANDROID_BLOCK_ON_PAUSE => "SDL_ANDROID_BLOCK_ON_PAUSE"u8;
 
+        [NativeTypeName("#define SDL_HINT_ANDROID_LOW_LATENCY_AUDIO \"SDL_ANDROID_LOW_LATENCY_AUDIO\"")]
+        public static ReadOnlySpan<byte> SDL_HINT_ANDROID_LOW_LATENCY_AUDIO => "SDL_ANDROID_LOW_LATENCY_AUDIO"u8;
+
         [NativeTypeName("#define SDL_HINT_ANDROID_TRAP_BACK_BUTTON \"SDL_ANDROID_TRAP_BACK_BUTTON\"")]
         public static ReadOnlySpan<byte> SDL_HINT_ANDROID_TRAP_BACK_BUTTON => "SDL_ANDROID_TRAP_BACK_BUTTON"u8;
 

--- a/SDL3-CS/SDL3/ClangSharp/SDL_iostream.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_iostream.g.cs
@@ -142,6 +142,14 @@ namespace SDL
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
+        public static extern SDLBool SDL_SaveFile_IO(SDL_IOStream* src, [NativeTypeName("const void *")] IntPtr data, [NativeTypeName("size_t")] nuint datasize, [NativeTypeName("bool")] SDLBool closeio);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("bool")]
+        public static extern SDLBool SDL_SaveFile([NativeTypeName("const char *")] byte* file, [NativeTypeName("const void *")] IntPtr data, [NativeTypeName("size_t")] nuint datasize);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("bool")]
         public static extern SDLBool SDL_ReadU8(SDL_IOStream* src, [NativeTypeName("Uint8 *")] byte* value);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]

--- a/SDL3-CS/SDL3/ClangSharp/SDL_version.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_version.g.cs
@@ -42,7 +42,7 @@ namespace SDL
         [NativeTypeName("#define SDL_MINOR_VERSION 1")]
         public const int SDL_MINOR_VERSION = 1;
 
-        [NativeTypeName("#define SDL_MICRO_VERSION 5")]
-        public const int SDL_MICRO_VERSION = 5;
+        [NativeTypeName("#define SDL_MICRO_VERSION 7")]
+        public const int SDL_MICRO_VERSION = 7;
     }
 }

--- a/SDL3-CS/SDL3/ClangSharp/SDL_video.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_video.g.cs
@@ -181,7 +181,7 @@ namespace SDL
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
-        public static extern SDLBool SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, float refresh_rate, [NativeTypeName("bool")] SDLBool include_high_density_modes, SDL_DisplayMode* mode);
+        public static extern SDLBool SDL_GetClosestFullscreenDisplayMode(SDL_DisplayID displayID, int w, int h, float refresh_rate, [NativeTypeName("bool")] SDLBool include_high_density_modes, SDL_DisplayMode* closest);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const SDL_DisplayMode *")]
@@ -841,6 +841,9 @@ namespace SDL
 
         [NativeTypeName("#define SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER \"SDL.window.wayland.surface\"")]
         public static ReadOnlySpan<byte> SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER => "SDL.window.wayland.surface"u8;
+
+        [NativeTypeName("#define SDL_PROP_WINDOW_WAYLAND_VIEWPORT_POINTER \"SDL.window.wayland.viewport\"")]
+        public static ReadOnlySpan<byte> SDL_PROP_WINDOW_WAYLAND_VIEWPORT_POINTER => "SDL.window.wayland.viewport"u8;
 
         [NativeTypeName("#define SDL_PROP_WINDOW_WAYLAND_EGL_WINDOW_POINTER \"SDL.window.wayland.egl_window\"")]
         public static ReadOnlySpan<byte> SDL_PROP_WINDOW_WAYLAND_EGL_WINDOW_POINTER => "SDL.window.wayland.egl_window"u8;

--- a/SDL3-CS/SDL3/SDL_pixels.cs
+++ b/SDL3-CS/SDL3/SDL_pixels.cs
@@ -5,6 +5,7 @@ using System;
 
 namespace SDL
 {
+    using static SDL_ArrayOrder;
     using static SDL_PixelFormat;
     using static SDL_PixelType;
     using static SDL_PackedOrder;
@@ -29,7 +30,13 @@ namespace SDL
         public static SDL_PixelType SDL_PIXELTYPE(SDL_PixelFormat X) => (SDL_PixelType)(((int)X >> 24) & 0x0F);
 
         [Macro]
-        public static SDL_PackedOrder SDL_PIXELORDER(SDL_PixelFormat X) => (SDL_PackedOrder)(((int)X >> 20) & 0x0F);
+        public static int SDL_PIXELORDER(SDL_PixelFormat X) => (((int)X >> 20) & 0x0F);
+
+        [Macro]
+        public static SDL_ArrayOrder SDL_PIXELORDER_Array(SDL_PixelFormat X) => (SDL_ArrayOrder)SDL_PIXELORDER(X);
+
+        [Macro]
+        public static SDL_PackedOrder SDL_PIXELORDER_Packed(SDL_PixelFormat X) => (SDL_PackedOrder)SDL_PIXELORDER(X);
 
         [Macro]
         public static SDL_PackedLayout SDL_PIXELLAYOUT(SDL_PixelFormat X) => (SDL_PackedLayout)(((int)X >> 16) & 0x0F);
@@ -73,14 +80,6 @@ namespace SDL
               (SDL_PIXELTYPE(format) == SDL_PIXELTYPE_ARRAYF32)));
 
         [Macro]
-        public static bool SDL_ISPIXELFORMAT_ALPHA(SDL_PixelFormat format) =>
-            ((SDL_ISPIXELFORMAT_PACKED(format) &&
-              ((SDL_PIXELORDER(format) == SDL_PACKEDORDER_ARGB) ||
-               (SDL_PIXELORDER(format) == SDL_PACKEDORDER_RGBA) ||
-               (SDL_PIXELORDER(format) == SDL_PACKEDORDER_ABGR) ||
-               (SDL_PIXELORDER(format) == SDL_PACKEDORDER_BGRA))));
-
-        [Macro]
         public static bool SDL_ISPIXELFORMAT_10BIT(SDL_PixelFormat format) =>
             (!SDL_ISPIXELFORMAT_FOURCC(format) &&
              ((SDL_PIXELTYPE(format) == SDL_PIXELTYPE_PACKED32) &&
@@ -95,6 +94,19 @@ namespace SDL
         [Macro]
         public static bool SDL_ISPIXELFORMAT_FOURCC(SDL_PixelFormat format) =>
             ((format != 0) && (SDL_PIXELFLAG(format) != 1));
+
+        [Macro]
+        public static bool SDL_ISPIXELFORMAT_ALPHA(SDL_PixelFormat format) =>
+            ((SDL_ISPIXELFORMAT_PACKED(format) &&
+              ((SDL_PIXELORDER_Packed(format) == SDL_PACKEDORDER_ARGB) ||
+               (SDL_PIXELORDER_Packed(format) == SDL_PACKEDORDER_RGBA) ||
+               (SDL_PIXELORDER_Packed(format) == SDL_PACKEDORDER_ABGR) ||
+               (SDL_PIXELORDER_Packed(format) == SDL_PACKEDORDER_BGRA))) ||
+             (SDL_ISPIXELFORMAT_ARRAY(format) &&
+              ((SDL_PIXELORDER_Array(format) == SDL_ARRAYORDER_ARGB) ||
+               (SDL_PIXELORDER_Array(format) == SDL_ARRAYORDER_RGBA) ||
+               (SDL_PIXELORDER_Array(format) == SDL_ARRAYORDER_ABGR) ||
+               (SDL_PIXELORDER_Array(format) == SDL_ARRAYORDER_BGRA))));
 
         [Macro]
         public static SDL_Colorspace SDL_DEFINE_COLORSPACE(UInt32 type, UInt32 range, UInt32 primaries, UInt32 transfer, UInt32 matrix, UInt32 chroma)


### PR DESCRIPTION
Updates bindings to https://github.com/libsdl-org/SDL/commit/e027b85cc457556071cbb2f3f1bcf8803c1bc001.

Importantly, this includes the changes to the `SDL_ISPIXELFORMAT_ALPHA` macro, which need to be added manually.