### PR TITLE
Specify default codesign key for iOS test project

### DIFF
--- a/SDL3-CS.Tests.iOS/SDL3-CS.Tests.iOS.csproj
+++ b/SDL3-CS.Tests.iOS/SDL3-CS.Tests.iOS.csproj
@@ -8,6 +8,7 @@
     <ImplicitUsings>true</ImplicitUsings>
     <SupportedOSPlatformVersion>13.0</SupportedOSPlatformVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Otherwise Rider will prompt me every time I try to run the test stating that a codesign key is missing. `iPhone Developer` is generally a sane default we use everywhere.