### PR TITLE
Fix `SDL_GetWindows()` managed helper

### DIFF
--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -32,6 +32,8 @@ namespace SDL.Tests
                 window.Setup();
                 window.Create();
 
+                printWindows();
+
                 const SDL_Keymod state = SDL_Keymod.SDL_KMOD_CAPS | SDL_Keymod.SDL_KMOD_ALT;
                 SDL_SetModState(state);
                 Debug.Assert(SDL_GetModState() == state);
@@ -62,6 +64,18 @@ namespace SDL.Tests
                     SDL_DisplayMode mode = modes[j];
                     Console.WriteLine($"{mode.w}x{mode.h}@{mode.refresh_rate}");
                 }
+            }
+        }
+
+        private static unsafe void printWindows()
+        {
+            using var windows = SDL_GetWindows();
+            if (windows == null)
+                return;
+
+            for (int i = 0; i < windows.Count; i++)
+            {
+                Console.WriteLine($"Window {i} title: {SDL_GetWindowTitle(windows[i])}");
             }
         }
     }

--- a/SDL3-CS/SDL3/SDL_video.cs
+++ b/SDL3-CS/SDL3/SDL_video.cs
@@ -107,11 +107,11 @@ namespace SDL
         }
 
         [MustDisposeResource]
-        public static unsafe SDLPointerArray<SDL_Window>? SDL_GetWindows()
+        public static unsafe SDLOpaquePointerArray<SDL_Window>? SDL_GetWindows()
         {
             int count;
             var array = SDL_GetWindows(&count);
-            return SDLArray.Create(array, count);
+            return SDLArray.CreateOpaque(array, count);
         }
     }
 }

--- a/SDL3-CS/SDLArray.cs
+++ b/SDL3-CS/SDLArray.cs
@@ -63,5 +63,15 @@ namespace SDL
 
             return new SDLPointerArray<T>(array, count);
         }
+
+        [MustDisposeResource]
+        internal static SDLOpaquePointerArray<T>? CreateOpaque<T>(T** array, int count)
+            where T : unmanaged
+        {
+            if (array == null)
+                return null;
+
+            return new SDLOpaquePointerArray<T>(array, count);
+        }
     }
 }

--- a/SDL3-CS/SDLOpaquePointerArray.cs
+++ b/SDL3-CS/SDLOpaquePointerArray.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using JetBrains.Annotations;
+
+namespace SDL
+{
+    [MustDisposeResource]
+    public sealed unsafe class SDLOpaquePointerArray<T> : IDisposable
+        where T : unmanaged
+    {
+        private readonly T** array;
+        public readonly int Count;
+        private bool isDisposed;
+
+        internal SDLOpaquePointerArray(T** array, int count)
+        {
+            this.array = array;
+            Count = count;
+        }
+
+        public T* this[int index]
+        {
+            get
+            {
+                ObjectDisposedException.ThrowIf(isDisposed, this);
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+                Debug.Assert(array[index] != null);
+                return array[index];
+            }
+        }
+
+        public void Dispose()
+        {
+            if (isDisposed)
+                return;
+
+            isDisposed = true;
+
+            SDL3.SDL_free(array);
+        }
+    }
+}


### PR DESCRIPTION
The current `SDL_GetWindows()` isn't useful, as the `SDLPointerArray<SDL_Window>` will give raw `SDL_Window` values. Instead, it should give `SDL_Window *` pointers.

This PR fixes that and adds a test.