### PR TITLE
Implement helper for `SDL_GetTrayEntries()`

### DIFF
--- a/SDL3-CS.Tests/TestTray.cs
+++ b/SDL3-CS.Tests/TestTray.cs
@@ -25,6 +25,13 @@ namespace SDL.Tests
             Assert.That(exit != null, SDL_GetError);
             SetCallback(exit, () => running = false);
 
+            var entries = SDL_GetTrayEntries(RootMenu);
+            Assert.That(entries, Is.Not.Null, SDL_GetError);
+            Assert.That(entries!.Count, Is.EqualTo(3));
+
+            for (int i = 0; i < entries.Count; i++)
+                Console.WriteLine($"{i}. {SDL_GetTrayEntryLabel(entries[i]) ?? "<null>"}");
+
             running = true;
 
             while (running)

--- a/SDL3-CS/SDL3/SDL_tray.cs
+++ b/SDL3-CS/SDL3/SDL_tray.cs
@@ -18,13 +18,11 @@ namespace SDL
 
     public static partial class SDL3
     {
-        // The code below is currently incorrect because of https://github.com/libsdl-org/SDL/issues/11787.
-        // [MustDisposeResource]
-        // public static unsafe SDLOpaquePointerArray<SDL_TrayEntry>? SDL_GetTrayEntries(SDL_TrayMenu* menu)
-        // {
-        //     int count;
-        //     var array = SDL_GetTrayEntries(menu, &count);
-        //     return SDLArray.CreateOpaque(array, count);
-        // }
+        public static unsafe SDLConstOpaquePointerArray<SDL_TrayEntry>? SDL_GetTrayEntries(SDL_TrayMenu* menu)
+        {
+            int count;
+            var array = SDL_GetTrayEntries(menu, &count);
+            return SDLArray.CreateConstOpaque(array, count);
+        }
     }
 }

--- a/SDL3-CS/SDLArray.cs
+++ b/SDL3-CS/SDLArray.cs
@@ -73,5 +73,14 @@ namespace SDL
 
             return new SDLOpaquePointerArray<T>(array, count);
         }
+
+        internal static SDLConstOpaquePointerArray<T>? CreateConstOpaque<T>(T** array, int count)
+            where T : unmanaged
+        {
+            if (array == null)
+                return null;
+
+            return new SDLConstOpaquePointerArray<T>(array, count);
+        }
     }
 }

--- a/SDL3-CS/SDLConstOpaquePointerArray.cs
+++ b/SDL3-CS/SDLConstOpaquePointerArray.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+
+namespace SDL
+{
+    public sealed unsafe class SDLConstOpaquePointerArray<T>
+        where T : unmanaged
+    {
+        private readonly T** array;
+        public readonly int Count;
+
+        internal SDLConstOpaquePointerArray(T** array, int count)
+        {
+            this.array = array;
+            Count = count;
+        }
+
+        public T* this[int index]
+        {
+            get
+            {
+                ArgumentOutOfRangeException.ThrowIfNegative(index);
+                ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(index, Count);
+                Debug.Assert(array[index] != null);
+                return array[index];
+            }
+        }
+    }
+}


### PR DESCRIPTION
- https://github.com/libsdl-org/SDL/issues/11787 was resolved as WAI, decision can only be found in the (wrongly named) https://github.com/libsdl-org/SDL/pull/11809#issuecomment-2568713535

The PR has no changes that matter for this, it just solidifies the documentation. So this helper can go in even if SDL is not updated.