### PR TITLE
Use ARM runners and Ubuntu 20.04 ARM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
           - { name: win-arm64,   os: windows-latest, flags: -A ARM64 }
           - { name: linux-x64,   os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":amd64" }
           - { name: linux-x86,   os: ubuntu-20.04,   flags: -GNinja -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32", target_apt_arch: ":i386" }
-          - { name: linux-arm64, os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":arm64", container: arm64v8/ubuntu, docker_platform: linux/arm64/v8 }
-          - { name: linux-arm,   os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":armhf", container: arm32v7/ubuntu, docker_platform: linux/arm/v7 }
+          - { name: linux-arm64, os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":arm64", container: "arm64v8/ubuntu:20.04", docker_platform: linux/arm64/v8 }
+          - { name: linux-arm,   os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":armhf", container: "arm32v7/ubuntu:20.04", docker_platform: linux/arm/v7 }
           - { name: osx-x64,     os: macos-latest,   flags: -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 }
           # NOTE: macOS 11.0 is the first released supported by Apple Silicon.
           - { name: osx-arm64,   os: macos-latest,   flags: -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
           submodules: true
 
       - name: Build (Linux ARM)
-        if: contains(matrix.platform.target_apt_arch, 'arm')
+        if: contains(matrix.platform.container, 'arm')
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ matrix.platform.container }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,27 +14,23 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { name: win-x64,     os: windows-latest, flags: -A x64 }
-          - { name: win-x86,     os: windows-latest, flags: -A Win32 }
-          - { name: win-arm64,   os: windows-latest, flags: -A ARM64 }
-          - { name: linux-x64,   os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":amd64" }
-          - { name: linux-x86,   os: ubuntu-20.04,   flags: -GNinja -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32", target_apt_arch: ":i386" }
-          - { name: linux-arm64, os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":arm64", container: "arm64v8/ubuntu:20.04", docker_platform: linux/arm64/v8 }
-          - { name: linux-arm,   os: ubuntu-20.04,   flags: -GNinja, target_apt_arch: ":armhf", container: "arm32v7/ubuntu:20.04", docker_platform: linux/arm/v7 }
-          - { name: osx-x64,     os: macos-latest,   flags: -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 }
+          - { name: win-x64,     os: windows-latest,   flags: -A x64 }
+          - { name: win-x86,     os: windows-latest,   flags: -A Win32 }
+          - { name: win-arm64,   os: windows-latest,   flags: -A ARM64 }
+          - { name: linux-x64,   os: ubuntu-20.04,     flags: -GNinja, target_apt_arch: ":amd64" }
+          - { name: linux-x86,   os: ubuntu-20.04,     flags: -GNinja -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32", target_apt_arch: ":i386" }
+          - { name: linux-arm64, os: ubuntu-22.04-arm, flags: -GNinja, target_apt_arch: ":arm64", container: "arm64v8/ubuntu:20.04" }
+          - { name: linux-arm,   os: ubuntu-22.04-arm, flags: -GNinja, target_apt_arch: ":armhf", container: "arm32v7/ubuntu:20.04" }
+          - { name: osx-x64,     os: macos-latest,     flags: -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 }
           # NOTE: macOS 11.0 is the first released supported by Apple Silicon.
-          - { name: osx-arm64,   os: macos-latest,   flags: -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 }
+          - { name: osx-arm64,   os: macos-latest,     flags: -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 }
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - name: Set up QEMU
-        if: contains(matrix.platform.container, 'arm')
-        uses: docker/setup-qemu-action@v3
-
       - name: Build (Linux ARM)
-        if: contains(matrix.platform.container, 'arm')
+        if: contains(matrix.platform.target_apt_arch, 'arm')
         uses: addnab/docker-run-action@v3
         with:
           image: ${{ matrix.platform.container }}
@@ -45,7 +41,6 @@ jobs:
             -e RUNNER_OS=${{ runner.os }}
             -e FLAGS=${{ matrix.platform.flags }}
             -e BUILD_TYPE=${{ env.BUILD_TYPE }}
-            --platform ${{ matrix.platform.docker_platform }}
           run: |
             cd /workspace
             ./External/build.sh

--- a/External/build.sh
+++ b/External/build.sh
@@ -12,6 +12,8 @@ fi
 
 SUDO=$(which sudo || exit 0)
 
+export DEBIAN_FRONTEND=noninteractive
+
 if [[ $RUNNER_OS == 'Linux' ]]; then
 # Setup Linux dependencies
     if [[ $TARGET_APT_ARCH == :i386 ]]; then


### PR DESCRIPTION
Surprisingly, we were using 24.04 to build Linux ARM binaries for quite long time... I found this while looking at Linux ARM build failures: https://github.com/ppy/SDL3-CS/actions/runs/12966332365

This PR lets ARM builds use public ARM runners and Ubuntu 20.04, and also fixes build failures. It speeds up ARM builds a lot, too! I needed to add `export DEBIAN_FRONTEND=noninteractive` because we cannot answer questions from packages. `export` is needed to carry environment variables to subprocesses.

I wanted to use `container` option rather than using `addnab/docker-run-action`, but I'm not sure how to make it only apply to ARM jobs.

Successful run: https://github.com/hwsmm/SDL3-CS/actions/runs/12967049556