### PR TITLE
Update dependencies for Ubuntu 22.04

### DIFF
--- a/External/build.sh
+++ b/External/build.sh
@@ -66,7 +66,8 @@ if [[ $RUNNER_OS == 'Linux' ]]; then
         libxxf86vm-dev$TARGET_APT_ARCH \
         libdrm-dev$TARGET_APT_ARCH \
         libgbm-dev$TARGET_APT_ARCH \
-        libpulse-dev$TARGET_APT_ARCH
+        libpulse-dev$TARGET_APT_ARCH \
+        libpipewire-0.3-dev$TARGET_APT_ARCH
 
     if [[ $TARGET_APT_ARCH != :i386 ]]; then
         # Build libdecor.

--- a/External/build.sh
+++ b/External/build.sh
@@ -67,22 +67,8 @@ if [[ $RUNNER_OS == 'Linux' ]]; then
         libdrm-dev$TARGET_APT_ARCH \
         libgbm-dev$TARGET_APT_ARCH \
         libpulse-dev$TARGET_APT_ARCH \
-        libpipewire-0.3-dev$TARGET_APT_ARCH
-
-    if [[ $TARGET_APT_ARCH != :i386 ]]; then
-        # Build libdecor.
-        # This is required so that window decorations can work on wayland.
-        # The support will only be enabled in SDL, but we're not shipping the libdecor binaries
-        # because making them work from a c# app as everything else does (via runtimes) is too difficult.
-        # Also skip i386 because attempting to support this for i386 is a pain.
-        # Special shoutouts to gnome for refusing to support server-side decorations.
-        git clone https://gitlab.freedesktop.org/libdecor/libdecor.git
-        cd libdecor
-        git checkout 0.2.2
-        meson build --buildtype release
-        $SUDO meson install -C build
-        cd ..
-    fi
+        libpipewire-0.3-dev$TARGET_APT_ARCH \
+        libdecor-0-dev$TARGET_APT_ARCH
 fi
 
 # Build SDL


### PR DESCRIPTION
We now have proper PipeWire and libdecor as GitHub is phasing out Ubuntu 20, so this PR tries to use them and removes a snippet that builds libdecor manually.

Successful run: https://github.com/hwsmm/SDL3-CS/actions/runs/13435741476