### PR TITLE
Allocate string memory only once in Utf8String when input lacks null terminator

### DIFF
--- a/SDL3-CS/Utf8String.cs
+++ b/SDL3-CS/Utf8String.cs
@@ -30,11 +30,9 @@ namespace SDL
             if (str[^1] == '\0')
                 return new Utf8String(Encoding.UTF8.GetBytes(str));
 
-            ReadOnlySpan<char> chars = str.AsSpan();
-            int len = Encoding.UTF8.GetByteCount(chars);
+            int len = Encoding.UTF8.GetByteCount(str);
             byte[] bytes = new byte[len + 1];
-            Encoding.UTF8.GetBytes(chars, bytes);
-
+            Encoding.UTF8.GetBytes(str, bytes);
             return new Utf8String(bytes);
         }
 
@@ -51,9 +49,7 @@ namespace SDL
 
             byte[] copy = new byte[raw.Length + 1];
             raw.CopyTo(copy);
-            raw = copy;
-
-            return new Utf8String(raw);
+            return new Utf8String(copy);
         }
 
         internal ref readonly byte GetPinnableReference() => ref Raw.GetPinnableReference();

--- a/SDL3-CS/Utf8String.cs
+++ b/SDL3-CS/Utf8String.cs
@@ -24,10 +24,18 @@ namespace SDL
             if (str == null)
                 return new Utf8String(null);
 
-            if (str.EndsWith('\0'))
+            if (str.Length == 0)
+                return new Utf8String("\0"u8);
+
+            if (str[^1] == '\0')
                 return new Utf8String(Encoding.UTF8.GetBytes(str));
 
-            return new Utf8String(Encoding.UTF8.GetBytes(str + '\0'));
+            ReadOnlySpan<char> chars = str.AsSpan();
+            int len = Encoding.UTF8.GetByteCount(chars);
+            byte[] bytes = new byte[len + 1];
+            Encoding.UTF8.GetBytes(chars, bytes);
+
+            return new Utf8String(bytes);
         }
 
         public static implicit operator Utf8String(ReadOnlySpan<byte> raw)
@@ -36,14 +44,14 @@ namespace SDL
                 return new Utf8String(null);
 
             if (raw.Length == 0)
-                return new Utf8String(new ReadOnlySpan<byte>([0]));
+                return new Utf8String("\0"u8);
 
-            if (raw[^1] != 0)
-            {
-                byte[] copy = new byte[raw.Length + 1];
-                raw.CopyTo(copy);
-                raw = copy;
-            }
+            if (raw[^1] == 0)
+                return new Utf8String(raw);
+
+            byte[] copy = new byte[raw.Length + 1];
+            raw.CopyTo(copy);
+            raw = copy;
 
             return new Utf8String(raw);
         }


### PR DESCRIPTION
The existing behavior of the `string?` conversion operator will allocate a new string (via concatenation) with only the null separator added, and then allocate a buffer for the byte conversion again using `GetBytes`. This PR changes the function such that it allocates the buffer only once in this situation, and no string concatenation is performed. This can cut down on GC pressure in projects that use `Utf8String` often.

Additionally, when creating `Utf8String` instances from an empty string, a compile-time constant with a single null terminator is used instead of allocating a new 1-element array. While the [UTF-8 string literals proposal](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-11.0/utf8-string-literals) states that a null terminator byte is added to the end of such constants automatically, by design that terminator is outside the `Span` and is therefore invisible to unit tests, which will fail without an explicit null terminator.

These changes pass all current tests under `TestUtf8String`.