### PR TITLE
Load SDL3 when using `SDL_image` or `SDL_ttf` members

### DIFF
--- a/SDL3_image-CS/SDL3_image/SDL_image.cs
+++ b/SDL3_image-CS/SDL3_image/SDL_image.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace SDL
 {
@@ -21,5 +22,13 @@ namespace SDL
     {
         [Constant]
         public static readonly int SDL_IMAGE_VERSION = SDL3.SDL_VERSIONNUM(SDL_IMAGE_MAJOR_VERSION, SDL_IMAGE_MINOR_VERSION, SDL_IMAGE_MICRO_VERSION);
+
+#pragma warning disable CA2255
+        [ModuleInitializer]
+        internal static void ModuleInitializer()
+        {
+            SDL3.SDL_Init(0);
+        }
+#pragma warning restore CA2255
     }
 }

--- a/SDL3_ttf-CS/SDL3_ttf/SDL_ttf.cs
+++ b/SDL3_ttf-CS/SDL3_ttf/SDL_ttf.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace SDL
 {
@@ -19,5 +20,13 @@ namespace SDL
     {
         [Constant]
         public static readonly int SDL_TTF_VERSION = SDL3.SDL_VERSIONNUM(SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, SDL_TTF_MICRO_VERSION);
+
+#pragma warning disable CA2255
+        [ModuleInitializer]
+        internal static void ModuleInitializer()
+        {
+            SDL3.SDL_Init(0);
+        }
+#pragma warning restore CA2255
     }
 }


### PR DESCRIPTION
Startup fails because the native SDL3 lib isn't loaded:

```
dlopen(/Users/smgi/Desktop/SDLImageTest/SDLImageTest/bin/Debug/net8.0/runtimes/osx-arm64/native/libSDL3_ttf.dylib, 0x0001): Library not loaded: @rpath/libSDL3.0.dylib
  Referenced from: <86C0A333-AD6F-3D99-8F4E-186F20B256BE> /Users/smgi/Desktop/SDLImageTest/SDLImageTest/bin/Debug/net8.0/runtimes/osx-arm64/native/libSDL3_ttf.dylib
  Reason: no LC_RPATH's found
```

Calling `SDL3.SDL_Init(0)` fixes this and relies on the .NET library resolution mechanism.