### PR TITLE
Add packages + platforms to README, general rewordings & improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 C# bindings for the [SDL3](https://github.com/libsdl-org/SDL) family of libraries.
 
-| Product                                                          | Package                                                                                                                                |
-|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| [`SDL`](https://github.com/libsdl-org/SDL/tree/main)             | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3-CS?label=ppy.SDL3-CS)](https://www.nuget.org/packages/ppy.SDL3-CS)                   |
-| [`SDL_image`](https://github.com/libsdl-org/SDL_image/tree/main) | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_image-CS?label=ppy.SDL3_image-CS)](https://www.nuget.org/packages/ppy.SDL3_image-CS) |
-| [`SDL_ttf`](https://github.com/libsdl-org/SDL_ttf/tree/main)     | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_ttf-CS?label=ppy.SDL3_ttf-CS)](https://www.nuget.org/packages/ppy.SDL3_ttf-CS)       |
+| Product                                                          | Usage                                  | Package                                                                                                                                
+|------------------------------------------------------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------
+| [`SDL`](https://github.com/libsdl-org/SDL/tree/main)             | `dotnet add package ppy.SDL3-CS`       | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3-CS?label=ppy.SDL3-CS)](https://www.nuget.org/packages/ppy.SDL3-CS)                   
+| [`SDL_image`](https://github.com/libsdl-org/SDL_image/tree/main) | `dotnet add package ppy.SDL3_image-CS` | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_image-CS?label=ppy.SDL3_image-CS)](https://www.nuget.org/packages/ppy.SDL3_image-CS) 
+| [`SDL_ttf`](https://github.com/libsdl-org/SDL_ttf/tree/main)     | `dotnet add package ppy.SDL3_ttf-CS`   | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_ttf-CS?label=ppy.SDL3_ttf-CS)](https://www.nuget.org/packages/ppy.SDL3_ttf-CS)       
 
 Contributions to keep the bindings up-to-date with upstream changes are welcome. If you have improvements or updates, feel free to submit a pull request.
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # SDL3-CS
 
-SDL3-CS is [SDL3](https://github.com/libsdl-org/SDL) bindings, developed for internal use and available publicly on [NuGet.org](https://www.nuget.org/packages/ppy.SDL3-CS).
+C# bindings for the [SDL3](https://github.com/libsdl-org/SDL) family of libraries.
 
-## About
+| Product                                                          | Package                                                                                                                                |
+|------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| [`SDL`](https://github.com/libsdl-org/SDL/tree/main)             | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3-CS?label=ppy.SDL3-CS)](https://www.nuget.org/packages/ppy.SDL3-CS)                   |
+| [`SDL_image`](https://github.com/libsdl-org/SDL_image/tree/main) | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_image-CS?label=ppy.SDL3_image-CS)](https://www.nuget.org/packages/ppy.SDL3_image-CS) |
+| [`SDL_ttf`](https://github.com/libsdl-org/SDL_ttf/tree/main)     | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_ttf-CS?label=ppy.SDL3_ttf-CS)](https://www.nuget.org/packages/ppy.SDL3_ttf-CS)       |
 
-The library is functional and available for public use. While it is actively maintained, updates are primarily driven by our internal needs. Please set your expectations accordingly when using or adapting SDL3-CS in your own projects.
+Contributions to keep the bindings up-to-date with upstream changes are welcome. If you have improvements or updates, feel free to submit a pull request.
 
-Contributions to keep the bindings up-to-date with upstream SDL3 changes are welcome. If you have improvements or updates, feel free to submit a pull request.
+## Platform support
 
-## Generating Bindings
+| Product         | `win-x64` | `win-x86` | `win-arm64` | `osx-arm64` | `osx-x64` | `linux-x64` | `linux-x86` | `linux-arm64` | `linux-arm` | `ios`   | `android` |
+|-----------------|-----------|-----------|-------------|-------------|-----------|-------------|-------------|---------------|-------------|---------|-----------|
+| `SDL3-CS`       | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
+| `SDL3_image-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         |           |
+| `SDL3_ttf-CS`   | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         |           |
 
-Bindings should be generated via the provided Dockerfile:
+## Generating bindings
+
+Bindings are generated via the provided Dockerfile:
 
 ```sh
 docker build -t 'sdl-gen' .

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 C# bindings for the [SDL3](https://github.com/libsdl-org/SDL) family of libraries.
 
-| Product                                                          | Usage                                  | Package                                                                                                                                
-|------------------------------------------------------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------
-| [`SDL`](https://github.com/libsdl-org/SDL/tree/main)             | `dotnet add package ppy.SDL3-CS`       | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3-CS?label=ppy.SDL3-CS)](https://www.nuget.org/packages/ppy.SDL3-CS)                   
-| [`SDL_image`](https://github.com/libsdl-org/SDL_image/tree/main) | `dotnet add package ppy.SDL3_image-CS` | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_image-CS?label=ppy.SDL3_image-CS)](https://www.nuget.org/packages/ppy.SDL3_image-CS) 
-| [`SDL_ttf`](https://github.com/libsdl-org/SDL_ttf/tree/main)     | `dotnet add package ppy.SDL3_ttf-CS`   | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_ttf-CS?label=ppy.SDL3_ttf-CS)](https://www.nuget.org/packages/ppy.SDL3_ttf-CS)       
+| Product                                                          | Usage                                  | Package                                                                                                                    |
+|------------------------------------------------------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| [`SDL`](https://github.com/libsdl-org/SDL/tree/main)             | `dotnet add package ppy.SDL3-CS`       | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3-CS?label=nuget)](https://www.nuget.org/packages/ppy.SDL3-CS)             |     
+| [`SDL_image`](https://github.com/libsdl-org/SDL_image/tree/main) | `dotnet add package ppy.SDL3_image-CS` | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_image-CS?label=nuget)](https://www.nuget.org/packages/ppy.SDL3_image-CS) | 
+| [`SDL_ttf`](https://github.com/libsdl-org/SDL_ttf/tree/main)     | `dotnet add package ppy.SDL3_ttf-CS`   | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_ttf-CS?label=nuget)](https://www.nuget.org/packages/ppy.SDL3_ttf-CS)     |
 
 Contributions to keep the bindings up-to-date with upstream changes are welcome. If you have improvements or updates, feel free to submit a pull request.
 

--- a/README_nuget.md
+++ b/README_nuget.md
@@ -1,0 +1,17 @@
+C# bindings for the [SDL3](https://github.com/libsdl-org/SDL) family of libraries.
+
+| Product                                                          | Usage                                  | Package                                                                                                                    |
+|------------------------------------------------------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| [`SDL`](https://github.com/libsdl-org/SDL/tree/main)             | `dotnet add package ppy.SDL3-CS`       | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3-CS?label=nuget)](https://www.nuget.org/packages/ppy.SDL3-CS)             |     
+| [`SDL_image`](https://github.com/libsdl-org/SDL_image/tree/main) | `dotnet add package ppy.SDL3_image-CS` | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_image-CS?label=nuget)](https://www.nuget.org/packages/ppy.SDL3_image-CS) | 
+| [`SDL_ttf`](https://github.com/libsdl-org/SDL_ttf/tree/main)     | `dotnet add package ppy.SDL3_ttf-CS`   | [![NuGet](https://img.shields.io/nuget/v/ppy.SDL3_ttf-CS?label=nuget)](https://www.nuget.org/packages/ppy.SDL3_ttf-CS)     |     
+
+Contributions to keep the bindings up-to-date with upstream changes are welcome. If you have improvements or updates, feel free to submit a pull request.
+
+## Platform support
+
+| Product         | `win-x64` | `win-x86` | `win-arm64` | `osx-arm64` | `osx-x64` | `linux-x64` | `linux-x86` | `linux-arm64` | `linux-arm` | `ios`   | `android` |
+|-----------------|-----------|-----------|-------------|-------------|-----------|-------------|-------------|---------------|-------------|---------|-----------|
+| `SDL3-CS`       | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
+| `SDL3_image-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         |           |
+| `SDL3_ttf-CS`   | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         |           |

--- a/SDL3-CS/SDL3-CS.csproj
+++ b/SDL3-CS/SDL3-CS.csproj
@@ -19,8 +19,13 @@
     <PackageReleaseNotes>Automated release.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ppy/SDL3-CS</PackageProjectUrl>
+    <PackageReadmeFile>README_nuget.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/ppy/SDL3-CS</RepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\README_nuget.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\SDL3-CS.SourceGeneration\SDL3-CS.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>

--- a/SDL3_image-CS/SDL3_image-CS.csproj
+++ b/SDL3_image-CS/SDL3_image-CS.csproj
@@ -17,8 +17,13 @@
     <PackageReleaseNotes>Automated release.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ppy/SDL3-CS</PackageProjectUrl>
+    <PackageReadmeFile>README_nuget.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/ppy/SDL3-CS</RepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\README_nuget.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\SDL3-CS.SourceGeneration\SDL3-CS.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>

--- a/SDL3_ttf-CS/SDL3_ttf-CS.csproj
+++ b/SDL3_ttf-CS/SDL3_ttf-CS.csproj
@@ -17,8 +17,13 @@
     <PackageReleaseNotes>Automated release.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ppy/SDL3-CS</PackageProjectUrl>
+    <PackageReadmeFile>README_nuget.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/ppy/SDL3-CS</RepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)..\README_nuget.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\SDL3-CS.SourceGeneration\SDL3-CS.SourceGeneration.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false"/>


### PR DESCRIPTION
- Adds a package list.
- Adds a platform support cross-table.
- Removes the blurb about this package being for internal use and to temper expectations. I register this as unnecessary and antithetical to fostering a mutually beneficial community.
- General rewordings because this project has expanded beyond `SDL` and now also contains bindings for `SDL_image` and `SDL_ttf` with additional targets arriving later as we/others need them.
- Adds readme to package.