### PR TITLE
Rework SDL_INIT_INTERFACE and add missing interfaces

### DIFF
--- a/SDL3-CS/SDL3/SDL_gpu.cs
+++ b/SDL3-CS/SDL3/SDL_gpu.cs
@@ -51,7 +51,10 @@ namespace SDL
         SDL_GPU_COLORCOMPONENT_A = (byte)SDL3.SDL_GPU_COLORCOMPONENT_A,
     }
 
-    public static partial class SDL3
+#pragma warning disable CS0618 // Type or member is obsolete
+    public partial struct SDL_GPURenderStateDesc : SDL3.ISDLInterface
+#pragma warning restore CS0618 // Type or member is obsolete
     {
+        uint SDL3.ISDLInterface.version { set => version = value; }
     }
 }

--- a/SDL3-CS/SDL3/SDL_iostream.cs
+++ b/SDL3-CS/SDL3/SDL_iostream.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace SDL
+{
+#pragma warning disable CS0618 // Type or member is obsolete
+    public partial struct SDL_IOStreamInterface : SDL3.ISDLInterface
+#pragma warning restore CS0618 // Type or member is obsolete
+    {
+        uint SDL3.ISDLInterface.version { set => version = value; }
+    }
+}

--- a/SDL3-CS/SDL3/SDL_joystick.cs
+++ b/SDL3-CS/SDL3/SDL_joystick.cs
@@ -19,4 +19,11 @@ namespace SDL
             return SDLArray.Create(array, count);
         }
     }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+    public partial struct SDL_VirtualJoystickDesc : SDL3.ISDLInterface
+#pragma warning restore CS0618 // Type or member is obsolete
+    {
+        uint SDL3.ISDLInterface.version { set => version = value; }
+    }
 }

--- a/SDL3-CS/SDL3/SDL_stdinc.cs
+++ b/SDL3-CS/SDL3/SDL_stdinc.cs
@@ -46,18 +46,20 @@ namespace SDL
         [Macro]
         public static uint SDL_FOURCC(byte A, byte B, byte C, byte D) => (uint)((A << 0) | (B << 8) | (C << 16) | (D << 24));
 
-        [Macro]
-        public static unsafe void SDL_INIT_INTERFACE(out SDL_IOStreamInterface iface)
+        [Obsolete("Do not use.")] // used internally
+        public interface ISDLInterface
         {
-            iface = default;
-            iface.version = (uint)sizeof(SDL_IOStreamInterface);
+            internal uint version { set; }
         }
 
         [Macro]
-        public static unsafe void SDL_INIT_INTERFACE(out SDL_StorageInterface iface)
+        public static unsafe void SDL_INIT_INTERFACE<T>(out T iface)
+#pragma warning disable CS0618 // Type or member is obsolete
+            where T : unmanaged, ISDLInterface
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             iface = default;
-            iface.version = (uint)sizeof(SDL_StorageInterface);
+            iface.version = (uint)sizeof(T);
         }
 
         public static unsafe void SDL_free(void* mem) => SDL_free((IntPtr)mem);

--- a/SDL3-CS/SDL3/SDL_storage.cs
+++ b/SDL3-CS/SDL3/SDL_storage.cs
@@ -7,6 +7,13 @@ using JetBrains.Annotations;
 
 namespace SDL
 {
+#pragma warning disable CS0618 // Type or member is obsolete
+    public partial struct SDL_StorageInterface : SDL3.ISDLInterface
+#pragma warning restore CS0618 // Type or member is obsolete
+    {
+        uint SDL3.ISDLInterface.version { set => version = value; }
+    }
+
     public static partial class SDL3
     {
         /// <returns>

--- a/SDL3_ttf-CS/SDL3_ttf/SDL_textengine.cs
+++ b/SDL3_ttf-CS/SDL3_ttf/SDL_textengine.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace SDL
+{
+#pragma warning disable CS0618 // Type or member is obsolete
+    public partial struct TTF_TextEngine : SDL3.ISDLInterface
+#pragma warning restore CS0618 // Type or member is obsolete
+    {
+        uint SDL3.ISDLInterface.version { set => version = value; }
+    }
+}


### PR DESCRIPTION
This rework allows usage of SDL_INIT_INTERFACE for types not defined in the base SDL3 library. This is needed for TTF_TextEngine.

Alternatively, the current SDL_INIT_INTERFACE implementation could be copy-pasted to the `SDL_ttf` class. This may marginally increase performance, but those looking for performance should just set the version field manually (this is [supported by SDL](https://wiki.libsdl.org/SDL3/SDL_INIT_INTERFACE) for "designated initializers").

This PR also adds SDL_INIT_INTERFACE support for SDL_GPURenderStateDesc, SDL_VirtualJoystickDesc and TTF_TextEngine.