### PR TITLE
Fix `Unsafe_` method generation in SDL_ttf

### DIFF
--- a/SDL3-CS.SourceGeneration/FriendlyOverloadGenerator.cs
+++ b/SDL3-CS.SourceGeneration/FriendlyOverloadGenerator.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
-
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -142,7 +141,10 @@ using System;
             if (gm.RequiredChanges.HasFlag(Changes.ChangeReturnTypeToString))
             {
                 expr = SyntaxFactory.InvocationExpression(
-                                        SyntaxFactory.IdentifierName("PtrToStringUTF8"))
+                                        SyntaxFactory.MemberAccessExpression(
+                                            SyntaxKind.SimpleMemberAccessExpression,
+                                            SyntaxFactory.IdentifierName("SDL3"),
+                                            SyntaxFactory.IdentifierName("PtrToStringUTF8")))
                                     .WithArguments(new[]
                                         {
                                             SyntaxFactory.Argument(makeFunctionCall(gm)),

--- a/SDL3-CS.Tests/TestTTF.cs
+++ b/SDL3-CS.Tests/TestTTF.cs
@@ -27,8 +27,7 @@ namespace SDL.Tests
                 try
                 {
                     Assert.That(font != null, SDL_GetError);
-                    string? name = PtrToStringUTF8(TTF_GetFontFamilyName(font)); // TODO: fix Unsafe_ generation
-                    Assert.That(name, Is.EqualTo("Times New Roman"));
+                    Assert.That(TTF_GetFontFamilyName(font), Is.EqualTo("Times New Roman"));
                 }
                 finally
                 {

--- a/SDL3-CS/generate_bindings.py
+++ b/SDL3-CS/generate_bindings.py
@@ -16,6 +16,7 @@ Usage:
 Example:
 - python generate_bindings.py
 - python generate_bindings.py SDL3/SDL_audio.h
+- python generate_bindings.py SDL3_ttf/SDL_ttf.h
 - python generate_bindings.py SDL_audio.h
 - python generate_bindings.py SDL_audio
 - python generate_bindings.py audio
@@ -365,7 +366,10 @@ def generate_platform_specific_headers(sdl_api, header: Header, platforms):
 def get_string_returning_functions(sdl_api):
     for f in sdl_api:
         if f["retval"] in ("const char*", "char*"):
-            yield f
+            yield f["name"]
+
+    yield "TTF_GetFontFamilyName"
+    yield "TTF_GetFontStyleName"
 
 
 def should_skip(solo_headers: list[Header], header: Header):
@@ -397,8 +401,7 @@ def main():
     str_ret_funcs = list(get_string_returning_functions(sdl_api))
     if str_ret_funcs:
         base_command.append("--remap")
-        for func in str_ret_funcs:
-            name = func["name"]
+        for name in str_ret_funcs:
             # add unsafe prefix to `const char *` functions so that the source generator can make friendly overloads with the unprefixed name.
             base_command.append(f"{name}={unsafe_prefix}{name}")
 

--- a/SDL3_ttf-CS/SDL3_ttf/ClangSharp/SDL_ttf.g.cs
+++ b/SDL3_ttf-CS/SDL3_ttf/ClangSharp/SDL_ttf.g.cs
@@ -257,13 +257,13 @@ namespace SDL
         [return: NativeTypeName("bool")]
         public static extern SDLBool TTF_FontIsScalable([NativeTypeName("const TTF_Font *")] TTF_Font* font);
 
-        [DllImport("SDL3_ttf", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("SDL3_ttf", CallingConvention = CallingConvention.Cdecl, EntryPoint = "TTF_GetFontFamilyName", ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
-        public static extern byte* TTF_GetFontFamilyName([NativeTypeName("const TTF_Font *")] TTF_Font* font);
+        public static extern byte* Unsafe_TTF_GetFontFamilyName([NativeTypeName("const TTF_Font *")] TTF_Font* font);
 
-        [DllImport("SDL3_ttf", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [DllImport("SDL3_ttf", CallingConvention = CallingConvention.Cdecl, EntryPoint = "TTF_GetFontStyleName", ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
-        public static extern byte* TTF_GetFontStyleName([NativeTypeName("const TTF_Font *")] TTF_Font* font);
+        public static extern byte* Unsafe_TTF_GetFontStyleName([NativeTypeName("const TTF_Font *")] TTF_Font* font);
 
         [DllImport("SDL3_ttf", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]


### PR DESCRIPTION
- Closes #218

The SDL_ttf methods are manually specified in `get_string_returning_functions()`, and the generated invocation of `PtrToStringUTF8()` is always prefixed: `SDL3.PtrToStringUTF8()` (even in cases where the `SDL3` class specifier is redundant).