### PR TITLE
Let SDL*_VERSION constants autogenerate

### DIFF
--- a/SDL3-CS/SDL3/ClangSharp/SDL_version.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_version.g.cs
@@ -44,5 +44,8 @@ namespace SDL
 
         [NativeTypeName("#define SDL_MICRO_VERSION 0")]
         public const int SDL_MICRO_VERSION = 0;
+
+        [NativeTypeName("#define SDL_VERSION SDL_VERSIONNUM(SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_MICRO_VERSION)")]
+        public const int SDL_VERSION = ((3) * 1000000 + (3) * 1000 + (0));
     }
 }

--- a/SDL3-CS/SDL3/SDL_version.cs
+++ b/SDL3-CS/SDL3/SDL_version.cs
@@ -18,9 +18,6 @@ namespace SDL
         [Macro]
         public static int SDL_VERSIONNUM_MICRO(int version) => ((version) % 1000);
 
-        [Constant]
-        public static readonly int SDL_VERSION = SDL_VERSIONNUM(SDL_MAJOR_VERSION, SDL_MINOR_VERSION, SDL_MICRO_VERSION);
-
         [Macro]
         public static bool SDL_VERSION_ATLEAST(int X, int Y, int Z) => SDL_VERSION >= SDL_VERSIONNUM(X, Y, Z);
     }

--- a/SDL3_image-CS/SDL3_image/ClangSharp/SDL_image.g.cs
+++ b/SDL3_image-CS/SDL3_image/ClangSharp/SDL_image.g.cs
@@ -251,5 +251,8 @@ namespace SDL
 
         [NativeTypeName("#define SDL_IMAGE_MICRO_VERSION 0")]
         public const int SDL_IMAGE_MICRO_VERSION = 0;
+
+        [NativeTypeName("#define SDL_IMAGE_VERSION SDL_VERSIONNUM(SDL_IMAGE_MAJOR_VERSION, SDL_IMAGE_MINOR_VERSION, SDL_IMAGE_MICRO_VERSION)")]
+        public const int SDL_IMAGE_VERSION = ((3) * 1000000 + (3) * 1000 + (0));
     }
 }

--- a/SDL3_image-CS/SDL3_image/SDL_image.cs
+++ b/SDL3_image-CS/SDL3_image/SDL_image.cs
@@ -5,9 +5,6 @@ namespace SDL
 {
     public static unsafe partial class SDL3_image
     {
-        [Constant]
-        public static readonly int SDL_IMAGE_VERSION = SDL3.SDL_VERSIONNUM(SDL_IMAGE_MAJOR_VERSION, SDL_IMAGE_MINOR_VERSION, SDL_IMAGE_MICRO_VERSION);
-
         [Macro]
         public static bool SDL_IMAGE_VERSION_ATLEAST(int X, int Y, int Z) =>
             ((SDL_IMAGE_MAJOR_VERSION >= X) &&

--- a/SDL3_ttf-CS/SDL3_ttf/ClangSharp/SDL_ttf.g.cs
+++ b/SDL3_ttf-CS/SDL3_ttf/ClangSharp/SDL_ttf.g.cs
@@ -545,6 +545,9 @@ namespace SDL
         [NativeTypeName("#define SDL_TTF_MICRO_VERSION 0")]
         public const int SDL_TTF_MICRO_VERSION = 0;
 
+        [NativeTypeName("#define SDL_TTF_VERSION SDL_VERSIONNUM(SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, SDL_TTF_MICRO_VERSION)")]
+        public const int SDL_TTF_VERSION = ((3) * 1000000 + (3) * 1000 + (0));
+
         [NativeTypeName("#define TTF_PROP_FONT_CREATE_FILENAME_STRING \"SDL_ttf.font.create.filename\"")]
         public static ReadOnlySpan<byte> TTF_PROP_FONT_CREATE_FILENAME_STRING => "SDL_ttf.font.create.filename"u8;
 

--- a/SDL3_ttf-CS/SDL3_ttf/SDL_ttf.cs
+++ b/SDL3_ttf-CS/SDL3_ttf/SDL_ttf.cs
@@ -29,9 +29,6 @@ namespace SDL
 
     public static unsafe partial class SDL3_ttf
     {
-        [Constant]
-        public static readonly int SDL_TTF_VERSION = SDL3.SDL_VERSIONNUM(SDL_TTF_MAJOR_VERSION, SDL_TTF_MINOR_VERSION, SDL_TTF_MICRO_VERSION);
-
         [Macro]
         public static bool SDL_TTF_VERSION_ATLEAST(int X, int Y, int Z) =>
             ((SDL_TTF_MAJOR_VERSION >= X) &&


### PR DESCRIPTION
Generation of SDL_VERSION constants was broken at some point, but looks like upstream SDL changes fixed it.