### PR TITLE
Mark `JetBrains.Annotations` as private package

### DIFF
--- a/SDL3-CS/SDL3-CS.csproj
+++ b/SDL3-CS/SDL3-CS.csproj
@@ -32,7 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0"/>
+    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
 
     <PackageReference Include="libclang" Version="17.0.4">
       <PrivateAssets>all</PrivateAssets>
@@ -100,7 +102,7 @@
       <PackagePath>runtimes/android-x86/native</PackagePath>
       <Pack>true</Pack>
     </None>
-    <EmbeddedJar Include="Jars\SDL3AndroidBridge.jar" />
+    <EmbeddedJar Include="Jars\SDL3AndroidBridge.jar"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Removes this package as a transitive dependency. Have tested that it still continues to work.

<img width="521" alt="image" src="https://github.com/user-attachments/assets/f3b527c7-705e-4721-9a11-72616b510d1c" />

See other usages for reference: https://grep.app/search?q=Include%3D%22JetBrains.Annotations%22