### PR TITLE
Add tests for checking equivalency of `SDL_GetPerformanceCounter()` and `Stopwatch.GetTimestamp()`

### DIFF
--- a/SDL3-CS.Tests/TestTimestampSource.cs
+++ b/SDL3-CS.Tests/TestTimestampSource.cs
@@ -1,0 +1,122 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using NUnit.Framework;
+
+namespace SDL.Tests
+{
+    /// <summary>
+    /// These tests check that <see cref="Stopwatch.GetTimestamp"/> and <see cref="SDL3.SDL_GetPerformanceCounter"/> use the same source of time.
+    /// </summary>
+    /// <remarks>
+    /// You also need to check that the clocks remain consistent even after the system is put to sleep. To do so:
+    /// <list type="number">
+    ///     <item>Run both tests normally.</item>
+    ///     <item>Run the tests one at a time, putting your computer to sleep while the test is running.
+    ///         Adjust <see cref="ITERATIONS"/> and <see cref="SLEEP_TIMEOUT"/> as needed.</item>
+    ///     <item>Run both tests normally. (Checks consistency after a sleep cycle.)</item>
+    /// </list>
+    /// </remarks>
+    public class TestTimestampSource
+    {
+        public const int ITERATIONS = 5;
+        public const int SLEEP_TIMEOUT = 200;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            SDL3.SDL_Init(0);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            SDL3.SDL_Quit();
+        }
+
+        [Test]
+        public void TestSDLBoundedByStopwatch()
+        {
+            Assert.That(SDL3.SDL_GetPerformanceFrequency(), Is.EqualTo(Stopwatch.Frequency));
+
+            DateTime? wallClockLastEnd = null;
+            long? lastEnd = null;
+
+            for (int i = 0; i < ITERATIONS; i++)
+            {
+                var wallClockStart = DateTime.UtcNow;
+
+                long stopwatchStart = Stopwatch.GetTimestamp();
+                ulong sdlTimestamp = SDL3.SDL_GetPerformanceCounter();
+                long stopwatchEnd = Stopwatch.GetTimestamp();
+
+                var wallClockEnd = DateTime.UtcNow;
+
+                Assert.That(sdlTimestamp, Is.GreaterThanOrEqualTo(stopwatchStart).And.LessThanOrEqualTo(stopwatchEnd));
+
+                if (lastEnd.HasValue && wallClockLastEnd.HasValue)
+                {
+                    long diff = stopwatchStart - lastEnd.Value;
+                    double seconds = (double)diff / Stopwatch.Frequency;
+                    double wallClockSeconds = (wallClockStart - wallClockLastEnd.Value).TotalSeconds;
+                    Console.WriteLine($"Elapsed inter-iteration: {diff} ({seconds} s), wall clock: {wallClockSeconds} s");
+                    Console.WriteLine();
+                }
+
+                Console.WriteLine($"Stw: {stopwatchStart}");
+                Console.WriteLine($"SDL: {sdlTimestamp}");
+                Console.WriteLine($"Stw: {stopwatchEnd}");
+                Console.WriteLine($"Elapsed this interation: {stopwatchEnd - stopwatchStart}");
+                Console.WriteLine();
+
+                lastEnd = stopwatchEnd;
+                wallClockLastEnd = wallClockEnd;
+
+                Thread.Sleep(SLEEP_TIMEOUT);
+            }
+        }
+
+        [Test]
+        public void TestStopwatchBoundedBySDL()
+        {
+            Assert.That(Stopwatch.Frequency, Is.EqualTo(SDL3.SDL_GetPerformanceFrequency()));
+
+            DateTime? wallClockLastEnd = null;
+            ulong? lastEnd = null;
+
+            for (int i = 0; i < ITERATIONS; i++)
+            {
+                var wallClockStart = DateTime.UtcNow;
+
+                ulong sdlStart = SDL3.SDL_GetPerformanceCounter();
+                long stopwatchTimestamp = Stopwatch.GetTimestamp();
+                ulong sdlEnd = SDL3.SDL_GetPerformanceCounter();
+
+                var wallClockEnd = DateTime.UtcNow;
+
+                Assert.That(stopwatchTimestamp, Is.GreaterThanOrEqualTo(sdlStart).And.LessThanOrEqualTo(sdlEnd));
+
+                if (lastEnd.HasValue && wallClockLastEnd.HasValue)
+                {
+                    ulong diff = sdlStart - lastEnd.Value;
+                    double seconds = (double)diff / SDL3.SDL_GetPerformanceFrequency();
+                    double wallClockSeconds = (wallClockStart - wallClockLastEnd.Value).TotalSeconds;
+                    Console.WriteLine($"Elapsed inter-iteration: {diff} ({seconds} s), wall clock: {wallClockSeconds} s");
+                    Console.WriteLine();
+                }
+
+                Console.WriteLine($"SDL: {sdlStart}");
+                Console.WriteLine($"Stw: {stopwatchTimestamp}");
+                Console.WriteLine($"SDL: {sdlEnd}");
+                Console.WriteLine($"Elapsed: {sdlEnd - sdlStart}");
+                Console.WriteLine();
+
+                lastEnd = sdlEnd;
+                wallClockLastEnd = wallClockEnd;
+
+                Thread.Sleep(SLEEP_TIMEOUT);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- First step towards https://github.com/ppy/osu-framework/issues/4808

SDL provides [nanosecond timestamps for all events](https://wiki.libsdl.org/SDL3/SDL_CommonEvent), but it is non-trivial to map these to the osu!framework `UpdateThread` clock (which uses a `Stopwatch`).

These tests can be used to verify that the two timestamp sources use the same underlying method on the current system.
If the two timestamp sources use the same underlying method (`QueryPerformanceCounter` on Windows), it's just a matter of accounting for the difference of epochs when timestamping events in osu!framework.

[`_startTimeStamp`](https://github.com/dotnet/runtime/blob/5535e31a712343a63f5d7d796cd874e563e5ac14/src/libraries/System.Private.CoreLib/src/System/Diagnostics/Stopwatch.cs#L42) is the epoch for [`Stopwatch.Elapsed`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.stopwatch.elapsed?view=net-8.0) values.
[`tick_start`](https://github.com/libsdl-org/SDL/blob/34928341d00d0f01e60fd6b89e6c9e6cdd2f890c/src/timer/SDL_timer.c#L608) is the epoch for [`SDL_GetTicksNS()`](https://wiki.libsdl.org/SDL3/SDL_GetTicksNS) values.

## Testing

- [x] Windows
- [ ] macOS
- [ ] Linux
- [ ] Android
- [ ] iOS