### PR TITLE
Build Android satellite libraries and refactor build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
 #    - cron: '0 0 * * *'
 env:
   BUILD_TYPE: Release
+  NDK_VER: 27.2.12479018
+  PLATFORM_VER: 35
 
 jobs:
   build:
@@ -24,10 +26,31 @@ jobs:
           - { name: osx-x64,     os: macos-13,     flags: -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.14 }
           # NOTE: macOS 11.0 is the first released supported by Apple Silicon.
           - { name: osx-arm64,   os: macos-latest,     flags: -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 }
+          - { name: android-arm64, os: ubuntu-22.04,  flags: -GNinja, abi: arm64-v8a }
+          - { name: android-arm,   os: ubuntu-22.04,  flags: -GNinja, abi: armeabi-v7a }
+          - { name: android-x64,   os: ubuntu-22.04,  flags: -GNinja, abi: x86_64 }
+          - { name: android-x86,   os: ubuntu-22.04,  flags: -GNinja, abi: x86 }
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+
+      - name: Setup JDK
+        if: contains(matrix.platform.name, 'android')
+        uses: actions/setup-java@v4
+        with:
+          distribution: microsoft
+          java-version: 17
+
+      - name: Install Android SDK Manager
+        if: contains(matrix.platform.name, 'android')
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK
+        if: contains(matrix.platform.name, 'android')
+        run: |
+          sdkmanager --install "platforms;android-$PLATFORM_VER"
+          sdkmanager --install "ndk;$NDK_VER"
 
       - name: Build (Linux ARM)
         if: contains(matrix.platform.container, 'arm')
@@ -52,6 +75,7 @@ jobs:
           TARGET_APT_ARCH: ${{ matrix.platform.target_apt_arch }}
           RUNNER_OS: ${{ runner.os }}
           FLAGS: ${{ matrix.platform.flags }}
+          ANDROID_ABI: ${{ matrix.platform.abi }}
         run: ./External/build.sh
 
       - name: Get Actions user id
@@ -66,7 +90,12 @@ jobs:
           user_id: ${{ steps.get_uid.outputs.uid }}
 
       - name: Compress native directory
-        run: tar -cf native-${{ matrix.platform.name }}.tar native/${{ matrix.platform.name }}
+        if: ${{ !contains(matrix.platform.name, 'android') }}
+        run: tar -cvf native-${{ matrix.platform.name }}.tar native/${{ matrix.platform.name }}
+
+      - name: Compress native directory (Android)
+        if: contains(matrix.platform.name, 'android')
+        run: tar -cvf native-${{ matrix.platform.name }}.tar native/android/${{ matrix.platform.abi }}
 
       - name: Upload native artifact
         uses: actions/upload-artifact@v4
@@ -100,7 +129,7 @@ jobs:
           cp External/SDL/Xcode/SDL/build/SDL3.xcframework/ios-arm64_x86_64-simulator/SDL3.framework/Info.plist native/ios/SDL3.xcframework/ios-arm64_x86_64-simulator/SDL3.framework/Info.plist;
 
       - name: Compress native directory
-        run: tar -cf native-ios.tar native/ios
+        run: tar -cvf native-ios.tar native/ios
 
       - name: Upload native artifact
         uses: actions/upload-artifact@v4
@@ -109,12 +138,9 @@ jobs:
           path: native-ios.tar
           if-no-files-found: error
 
-  build-android:
-    name: android
+  build-android-jar:
+    name: android-jar
     runs-on: ubuntu-22.04
-    env:
-      NDK_VER: 23.1.7779620
-      PLATFORM_VER: android-34
     steps:
       - uses: actions/checkout@v4
         with:
@@ -130,22 +156,10 @@ jobs:
 
       - name: Install Android SDK Manager
         uses: android-actions/setup-android@v3
-        with:
-          packages: ''
 
       - name: Install Android SDK
         run: |
-          sdkmanager --install "platform-tools" "platforms;$PLATFORM_VER"
-          sdkmanager --install "ndk;$NDK_VER" --channel=3
-
-      - name: Build (Android)
-        run: |
-          export PATH=$ANDROID_HOME/ndk/$NDK_VER:$PATH
-          export OUTPUT=$PWD/native/android
-          rm -rf $OUTPUT && mkdir -p $OUTPUT
-
-          # Build SDL3
-          ./External/SDL/build-scripts/androidbuildlibs.sh APP_ABI="armeabi-v7a arm64-v8a x86 x86_64" NDK_LIBS_OUT="$OUTPUT"
+          sdkmanager --install "platforms;android-$PLATFORM_VER"
 
       - name: Build SDL3 Android Java
         run: |
@@ -156,18 +170,8 @@ jobs:
 
           # Build SDL3 Android Java part
           cd ./External/SDL/android-project/app/src/main/java
-          javac -cp $ANDROID_HOME/platforms/$PLATFORM_VER/android.jar -encoding utf8 org/libsdl/app/*.java
+          javac -cp $ANDROID_HOME/platforms/android-$PLATFORM_VER/android.jar -encoding utf8 org/libsdl/app/*.java
           jar cvf $OUTPUT/SDL3AndroidBridge.jar org/libsdl/app/*.class
-
-      - name: Compress native directory
-        run: tar -cf native-android.tar native/android
-
-      - name: Upload native artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: native-android
-          path: native-android.tar
-          if-no-files-found: error
 
       - name: Upload JAR artifact
         uses: actions/upload-artifact@v4
@@ -179,7 +183,7 @@ jobs:
   make-pr:
     name: Submit pull request
     runs-on: ubuntu-latest
-    needs: [ build, build-ios, build-android ]
+    needs: [ build, build-ios, build-android-jar ]
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -338,3 +338,5 @@ inspectcodereport.xml
 inspectcode
 
 sdl.json
+
+install_output/

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Contributions to keep the bindings up-to-date with upstream changes are welcome.
 | Product         | `win-x64` | `win-x86` | `win-arm64` | `osx-arm64` | `osx-x64` | `linux-x64` | `linux-x86` | `linux-arm64` | `linux-arm` | `ios`   | `android` |
 |-----------------|-----------|-----------|-------------|-------------|-----------|-------------|-------------|---------------|-------------|---------|-----------|
 | `SDL3-CS`       | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
-| `SDL3_image-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         |           |
-| `SDL3_ttf-CS`   | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         |           |
-| `SDL3_mixer-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         |           |
+| `SDL3_image-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         | &check;   |
+| `SDL3_ttf-CS`   | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         | &check;   |
+| `SDL3_mixer-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     |         | &check;   |
 
 ## Generating bindings
 

--- a/SDL3-CS.Tests.Android/MainActivity.cs
+++ b/SDL3-CS.Tests.Android/MainActivity.cs
@@ -5,7 +5,7 @@ namespace SDL.Tests.Android
     [Activity(Label = "SDL3-CS Android Tests", MainLauncher = true)]
     public class MainActivity : SDLActivity
     {
-        protected override string[] GetLibraries() => ["SDL3"];
+        protected override string[] GetLibraries() => ["SDL3", "SDL3_image", "SDL3_ttf"];
 
         protected override void Main() => Program.Main();
     }

--- a/SDL3-CS.Tests.Android/MainActivity.cs
+++ b/SDL3-CS.Tests.Android/MainActivity.cs
@@ -5,7 +5,7 @@ namespace SDL.Tests.Android
     [Activity(Label = "SDL3-CS Android Tests", MainLauncher = true)]
     public class MainActivity : SDLActivity
     {
-        protected override string[] GetLibraries() => ["SDL3", "SDL3_image", "SDL3_ttf"];
+        protected override string[] GetLibraries() => ["SDL3", "SDL3_image", "SDL3_ttf", "SDL3_mixer"];
 
         protected override void Main() => Program.Main();
     }

--- a/SDL3-CS.Tests.Android/SDL3-CS.Tests.Android.csproj
+++ b/SDL3-CS.Tests.Android/SDL3-CS.Tests.Android.csproj
@@ -9,6 +9,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationId>SDL.Tests.Android</ApplicationId>
+    <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
   </PropertyGroup>
 
   <PropertyGroup Label="NuGet">
@@ -30,6 +31,42 @@
       <Abi>x86</Abi>
     </AndroidNativeLibrary>
     <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\libSDL3.so">
+      <Abi>x86_64</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3_image.so">
+      <Abi>armeabi-v7a</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\libSDL3_image.so">
+      <Abi>arm64-v8a</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\libSDL3_image.so">
+      <Abi>x86</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\libSDL3_image.so">
+      <Abi>x86_64</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3_ttf.so">
+      <Abi>armeabi-v7a</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\libSDL3_ttf.so">
+      <Abi>arm64-v8a</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\libSDL3_ttf.so">
+      <Abi>x86</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\libSDL3_ttf.so">
+      <Abi>x86_64</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3_mixer.so">
+      <Abi>armeabi-v7a</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\libSDL3_mixer.so">
+      <Abi>arm64-v8a</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\libSDL3_mixer.so">
+      <Abi>x86</Abi>
+    </AndroidNativeLibrary>
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\libSDL3_mixer.so">
       <Abi>x86_64</Abi>
     </AndroidNativeLibrary>
   </ItemGroup>

--- a/SDL3-CS.Tests/Program.cs
+++ b/SDL3-CS.Tests/Program.cs
@@ -3,6 +3,9 @@
 
 using System.Diagnostics;
 using System.Text;
+using static SDL.SDL3_image;
+using static SDL.SDL3_ttf;
+using static SDL.SDL3_mixer;
 using static SDL.SDL3;
 
 namespace SDL.Tests
@@ -25,7 +28,8 @@ namespace SDL.Tests
 
             using (var window = new MyWindow())
             {
-                Console.WriteLine($"SDL revision: {SDL_GetRevision()}");
+                // Check if satellite libraries exist.
+                Console.WriteLine($"SDL revision: {SDL_GetRevision()}, IMG {IMG_Version()}, TTF {TTF_Version()}, Mixer {Mix_Version()}");
 
                 printDisplays();
 

--- a/SDL3-CS.Tests/SDL3-CS.Tests.csproj
+++ b/SDL3-CS.Tests/SDL3-CS.Tests.csproj
@@ -24,6 +24,7 @@
     <ProjectReference Include="..\SDL3-CS\SDL3-CS.csproj"/>
     <ProjectReference Include="..\SDL3_image-CS\SDL3_image-CS.csproj"/>
     <ProjectReference Include="..\SDL3_ttf-CS\SDL3_ttf-CS.csproj"/>
+    <ProjectReference Include="..\SDL3_mixer-CS\SDL3_mixer-CS.csproj"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/SDL3_image-CS/SDL3_image-CS.csproj
+++ b/SDL3_image-CS/SDL3_image-CS.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <RootNamespace>SDL</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -72,6 +73,7 @@
       <PackagePath>runtimes/ios/native/SDL3.xcframework</PackagePath>
       <Pack>true</Pack>
     </None>
+    -->
     <None Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3_image.so">
       <PackagePath>runtimes/android-arm/native</PackagePath>
       <Pack>true</Pack>
@@ -88,7 +90,6 @@
       <PackagePath>runtimes/android-x86/native</PackagePath>
       <Pack>true</Pack>
     </None>
-    -->
   </ItemGroup>
 
 </Project>

--- a/SDL3_mixer-CS/SDL3_mixer-CS.csproj
+++ b/SDL3_mixer-CS/SDL3_mixer-CS.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <RootNamespace>SDL</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -72,6 +73,7 @@
       <PackagePath>runtimes/ios/native/SDL3.xcframework</PackagePath>
       <Pack>true</Pack>
     </None>
+    -->
     <None Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3_mixer.so">
       <PackagePath>runtimes/android-arm/native</PackagePath>
       <Pack>true</Pack>
@@ -88,7 +90,6 @@
       <PackagePath>runtimes/android-x86/native</PackagePath>
       <Pack>true</Pack>
     </None>
-    -->
   </ItemGroup>
 
 </Project>

--- a/SDL3_ttf-CS/SDL3_ttf-CS.csproj
+++ b/SDL3_ttf-CS/SDL3_ttf-CS.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <RootNamespace>SDL</RootNamespace>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -72,6 +73,7 @@
       <PackagePath>runtimes/ios/native/SDL3.xcframework</PackagePath>
       <Pack>true</Pack>
     </None>
+    -->
     <None Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3_ttf.so">
       <PackagePath>runtimes/android-arm/native</PackagePath>
       <Pack>true</Pack>
@@ -88,7 +90,6 @@
       <PackagePath>runtimes/android-x86/native</PackagePath>
       <Pack>true</Pack>
     </None>
-    -->
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR makes Android builds use CMake instead of ndk-build to build satellite libraries, and refactor the build script.

I actually tried using CMake a few months ago, but it produced pretty big binaries then, so I didn't bother making a PR.
However, we now have satellite libraries, and it's not easy to build them with ndk-build.

It may be better if we strip the library, but I think it's not that bad to be consistent with existing builds. SDL also distributes big libraries: https://github.com/libsdl-org/SDL/releases/download/release-3.2.16/SDL3-devel-3.2.16-android.zip

This PR doesn't build iOS binaries, so it doesn't completely resolve #212. I'll leave it to someone else because I don't have any Apple devices to test on.

Also, this PR fixes an issue where SDL_mixer wasn't being built statically.

Successful run: https://github.com/hwsmm/SDL3-CS/actions/runs/15954437620 (https://github.com/hwsmm/SDL3-CS/pull/10/files)