### PR TITLE
Upgrade NDK to r28c

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 #    - cron: '0 0 * * *'
 env:
   BUILD_TYPE: Release
-  NDK_VER: 27.2.12479018
+  NDK_VER: 28.2.13676358
   PLATFORM_VER: 35
 
 jobs:


### PR DESCRIPTION
Matching upstream: https://github.com/libsdl-org/SDL/blob/5f77da3a5025b92500c32d0dc7962d22fc79a8c7/.github/workflows/release.yml#L534-L539

Starting November 1st, all apps will need to [support 16KiB page sizes](https://developer.android.com/guide/practices/page-sizes). This was first introduced in r28: https://github.com/android/ndk/wiki/Changelog-r28

Completed run: https://github.com/smoogipoo/SDL3-CS/actions/runs/17018432048