### PR TITLE
Improve local builds

### DIFF
--- a/SDL3-CS.Android.slnf
+++ b/SDL3-CS.Android.slnf
@@ -2,12 +2,13 @@
   "solution": {
     "path": "SDL3-CS.sln",
     "projects": [
-      "SDL3-CS\\SDL3-CS.csproj",
-      "SDL3_ttf-CS\\SDL3_ttf-CS.csproj",
-      "SDL3_image-CS\\SDL3_image-CS.csproj",
       "SDL3-CS.SourceGeneration\\SDL3-CS.SourceGeneration.csproj",
+      "SDL3-CS.Tests.Android\\SDL3-CS.Tests.Android.csproj",
       "SDL3-CS.Tests\\SDL3-CS.Tests.csproj",
-      "SDL3-CS.Tests.Android\\SDL3-CS.Tests.Android.csproj"
+      "SDL3-CS\\SDL3-CS.csproj",
+      "SDL3_image-CS\\SDL3_image-CS.csproj",
+      "SDL3_mixer-CS\\SDL3_mixer-CS.csproj",
+      "SDL3_ttf-CS\\SDL3_ttf-CS.csproj"
     ]
   }
 }

--- a/SDL3-CS.Desktop.slnf
+++ b/SDL3-CS.Desktop.slnf
@@ -2,12 +2,13 @@
   "solution": {
     "path": "SDL3-CS.sln",
     "projects": [
-      "SDL3-CS\\SDL3-CS.csproj",
-      "SDL3_ttf-CS\\SDL3_ttf-CS.csproj",
-      "SDL3_image-CS\\SDL3_image-CS.csproj",
       "SDL3-CS.SourceGeneration\\SDL3-CS.SourceGeneration.csproj",
+      "SDL3-CS.Tests.Desktop\\SDL3-CS.Tests.Desktop.csproj",
       "SDL3-CS.Tests\\SDL3-CS.Tests.csproj",
-      "SDL3-CS.Tests.Desktop\\SDL3-CS.Tests.Desktop.csproj"
+      "SDL3-CS\\SDL3-CS.csproj",
+      "SDL3_image-CS\\SDL3_image-CS.csproj",
+      "SDL3_mixer-CS\\SDL3_mixer-CS.csproj",
+      "SDL3_ttf-CS\\SDL3_ttf-CS.csproj"
     ]
   }
 }

--- a/SDL3-CS.Tests.Android/SDL3-CS.Tests.Android.csproj
+++ b/SDL3-CS.Tests.Android/SDL3-CS.Tests.Android.csproj
@@ -21,52 +21,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3.so">
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\*.so">
       <Abi>armeabi-v7a</Abi>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\libSDL3.so">
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\*.so">
       <Abi>arm64-v8a</Abi>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\libSDL3.so">
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\*.so">
       <Abi>x86</Abi>
     </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\libSDL3.so">
-      <Abi>x86_64</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3_image.so">
-      <Abi>armeabi-v7a</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\libSDL3_image.so">
-      <Abi>arm64-v8a</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\libSDL3_image.so">
-      <Abi>x86</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\libSDL3_image.so">
-      <Abi>x86_64</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3_ttf.so">
-      <Abi>armeabi-v7a</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\libSDL3_ttf.so">
-      <Abi>arm64-v8a</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\libSDL3_ttf.so">
-      <Abi>x86</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\libSDL3_ttf.so">
-      <Abi>x86_64</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\armeabi-v7a\libSDL3_mixer.so">
-      <Abi>armeabi-v7a</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\arm64-v8a\libSDL3_mixer.so">
-      <Abi>arm64-v8a</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86\libSDL3_mixer.so">
-      <Abi>x86</Abi>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\libSDL3_mixer.so">
+    <AndroidNativeLibrary Include="$(MSBuildThisFileDirectory)..\native\android\x86_64\*.so">
       <Abi>x86_64</Abi>
     </AndroidNativeLibrary>
   </ItemGroup>

--- a/SDL3-CS.Tests.Desktop/SDL3-CS.Tests.Desktop.csproj
+++ b/SDL3-CS.Tests.Desktop/SDL3-CS.Tests.Desktop.csproj
@@ -17,21 +17,12 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <SDLArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)</SDLArch>
-
-    <!-- If RID is specified -->
-    <SDLNativeLib Condition=" $(RuntimeIdentifier.StartsWith('win')) ">$(RuntimeIdentifier)\SDL3.dll</SDLNativeLib>
-    <SDLNativeLib Condition=" $(RuntimeIdentifier.StartsWith('linux')) ">$(RuntimeIdentifier)\libSDL3.so</SDLNativeLib>
-    <SDLNativeLib Condition=" $(RuntimeIdentifier.StartsWith('osx')) ">$(RuntimeIdentifier)\libSDL3.dylib</SDLNativeLib>
-
-    <!-- If RID is not specified -->
-    <SDLNativeLib Condition=" '$(SDLNativeLib)' == '' And '$([MSBuild]::IsOSPlatform(Windows))' ">win-$(SDLArch.ToLower())\SDL3.dll</SDLNativeLib>
-    <SDLNativeLib Condition=" '$(SDLNativeLib)' == '' And '$([MSBuild]::IsOSPlatform(Linux))' ">linux-$(SDLArch.ToLower())\libSDL3.so</SDLNativeLib>
-    <SDLNativeLib Condition=" '$(SDLNativeLib)' == '' And '$([MSBuild]::IsOSPlatform(OSX))' ">osx-$(SDLArch.ToLower())\libSDL3.dylib</SDLNativeLib>
+    <SDLArch Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</SDLArch>
+    <SDLArch Condition="'$(RuntimeIdentifier)' != ''">$(RuntimeIdentifier)</SDLArch>
   </PropertyGroup>
 
   <ItemGroup>
-    <Content Include="$(MSBuildThisFileDirectory)..\native\$(SDLNativeLib)">
+    <Content Include="$(MSBuildThisFileDirectory)..\native\$(SDLArch)\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/SDL3-CS.Tests.iOS/Main.cs
+++ b/SDL3-CS.Tests.iOS/Main.cs
@@ -7,6 +7,9 @@ public class Program
     public static unsafe void Main(string[] args)
     {
         NativeLibrary.SetDllImportResolver(typeof(SDL3).Assembly, (_, assembly, path) => NativeLibrary.Load("@rpath/SDL3.framework/SDL3", assembly, path));
+        NativeLibrary.SetDllImportResolver(typeof(SDL3_image).Assembly, (_, assembly, path) => NativeLibrary.Load("@rpath/SDL3_image.framework/SDL3_image", assembly, path));
+        NativeLibrary.SetDllImportResolver(typeof(SDL3_ttf).Assembly, (_, assembly, path) => NativeLibrary.Load("@rpath/SDL3_ttf.framework/SDL3_ttf", assembly, path));
+        NativeLibrary.SetDllImportResolver(typeof(SDL3_mixer).Assembly, (_, assembly, path) => NativeLibrary.Load("@rpath/SDL3_mixer.framework/SDL3_mixer", assembly, path));
 
         SDL3.SDL_RunApp(0, null, &main, IntPtr.Zero);
     }

--- a/SDL3-CS.Tests.iOS/SDL3-CS.Tests.iOS.csproj
+++ b/SDL3-CS.Tests.iOS/SDL3-CS.Tests.iOS.csproj
@@ -21,6 +21,9 @@
 
   <ItemGroup>
     <NativeReference Include="$(MSBuildThisFileDirectory)..\native\ios\SDL3.xcframework"/>
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\native\ios\SDL3_image.xcframework"/>
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\native\ios\SDL3_ttf.xcframework"/>
+    <NativeReference Include="$(MSBuildThisFileDirectory)..\native\ios\SDL3_mixer.xcframework"/>
   </ItemGroup>
 
 </Project>

--- a/SDL3-CS.iOS.slnf
+++ b/SDL3-CS.iOS.slnf
@@ -2,12 +2,13 @@
   "solution": {
     "path": "SDL3-CS.sln",
     "projects": [
-      "SDL3-CS\\SDL3-CS.csproj",
-      "SDL3_ttf-CS\\SDL3_ttf-CS.csproj",
-      "SDL3_image-CS\\SDL3_image-CS.csproj",
       "SDL3-CS.SourceGeneration\\SDL3-CS.SourceGeneration.csproj",
+      "SDL3-CS.Tests.iOS\\SDL3-CS.Tests.iOS.csproj",
       "SDL3-CS.Tests\\SDL3-CS.Tests.csproj",
-      "SDL3-CS.Tests.iOS\\SDL3-CS.Tests.iOS.csproj"
+      "SDL3-CS\\SDL3-CS.csproj",
+      "SDL3_image-CS\\SDL3_image-CS.csproj",
+      "SDL3_mixer-CS\\SDL3_mixer-CS.csproj",
+      "SDL3_ttf-CS\\SDL3_ttf-CS.csproj"
     ]
   }
 }

--- a/SDL3-CS/JetBrainsAnnotations.cs
+++ b/SDL3-CS/JetBrainsAnnotations.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+// https://github.com/JetBrains/JetBrains.Annotations/blob/988289d09aad925b22a5321c075a735cb9597e59/src/Annotations.cs
+namespace JetBrains.Annotations
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Parameter)]
+    internal sealed class MustDisposeResourceAttribute : Attribute
+    {
+        public MustDisposeResourceAttribute()
+        {
+            Value = true;
+        }
+
+        public MustDisposeResourceAttribute(bool value)
+        {
+            Value = value;
+        }
+
+        /// <summary>
+        /// When set to <c>false</c>, disposing of the resource is not obligatory.
+        /// The main use-case for explicit <c>[MustDisposeResource(false)]</c> annotation
+        /// is to loosen the annotation for inheritors.
+        /// </summary>
+        public bool Value { get; }
+    }
+}

--- a/SDL3-CS/SDL3-CS.csproj
+++ b/SDL3-CS/SDL3-CS.csproj
@@ -32,10 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" Version="2023.3.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-
     <PackageReference Include="libclang" Version="17.0.4">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
A few issues here:
- `SDL3_mixer` project wasn't included in any filtered solutions.
- The desktop project didn't include all other libs - only SDL.
- The iOS project didn't include all other libs - only SDL.
- The iOS project crashed at runtime due to an AOT exception. Fixed by removing JetBrains.Annotations package.