### PR TITLE
Fix bindings not compiling

### DIFF
--- a/SDL3-CS/SDL3/SDL_gpu.cs
+++ b/SDL3-CS/SDL3/SDL_gpu.cs
@@ -50,11 +50,4 @@ namespace SDL
         SDL_GPU_COLORCOMPONENT_B = (byte)SDL3.SDL_GPU_COLORCOMPONENT_B,
         SDL_GPU_COLORCOMPONENT_A = (byte)SDL3.SDL_GPU_COLORCOMPONENT_A,
     }
-
-#pragma warning disable CS0618 // Type or member is obsolete
-    public partial struct SDL_GPURenderStateDesc : SDL3.ISDLInterface
-#pragma warning restore CS0618 // Type or member is obsolete
-    {
-        uint SDL3.ISDLInterface.version { set => version = value; }
-    }
 }


### PR DESCRIPTION
`SDL_GPURenderStateDesc` was removed in favour of [`SDL_GPURenderStateCreateInfo`](https://wiki.libsdl.org/SDL3/SDL_GPURenderStateCreateInfo), which doesn't include a `version` field.