### PR TITLE
Add CI build workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     name: Build only (Desktop)
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      CI_DONT_TARGET_ANDROID: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,6 +56,8 @@ jobs:
     name: Build only (iOS)
     runs-on: macos-15
     timeout-minutes: 60
+    env:
+      CI_DONT_TARGET_ANDROID: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: Continuous Integration
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  build-only-desktop:
+    name: Build only (Desktop)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install .NET 8.0.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Build
+        run: dotnet build -c Debug SDL3-CS.Desktop.slnf
+
+  build-only-android:
+    name: Build only (Android)
+    runs-on: windows-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: microsoft
+          java-version: 11
+
+      - name: Install .NET 8.0.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Install .NET workloads
+        run: dotnet workload install android
+
+      - name: Build
+        run: dotnet build -c Debug SDL3-CS.Android.slnf
+
+  build-only-ios:
+    name: Build only (iOS)
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install .NET 8.0.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Install .NET Workloads
+        run: dotnet workload install ios
+
+      # https://github.com/dotnet/macios/issues/19157
+      # https://github.com/actions/runner-images/issues/12758
+      - name: Use Xcode 16.4
+        run: sudo xcode-select -switch /Applications/Xcode_16.4.app
+
+      - name: Build
+        run: dotnet build -c Debug SDL3-CS.iOS.slnf

--- a/SDL3-CS.Tests/SDL3-CS.Tests.csproj
+++ b/SDL3-CS.Tests/SDL3-CS.Tests.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\External\SDL_image\test\sample.png">
+    <None Include="..\External\SDL_image\test\sample.png" Condition="Exists('..\External\SDL_image\test\sample.png')">
       <Link>sample.png</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/SDL3-CS/SDL3-CS.csproj
+++ b/SDL3-CS/SDL3-CS.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <RootNamespace>SDL</RootNamespace>
-    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(CI_DONT_TARGET_ANDROID)' != '1' ">net8.0;net8.0-android</TargetFrameworks>
+    <TargetFramework Condition=" '$(CI_DONT_TARGET_ANDROID)' == '1' ">net8.0</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/SDL3_image-CS/SDL3_image-CS.csproj
+++ b/SDL3_image-CS/SDL3_image-CS.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(CI_DONT_TARGET_ANDROID)' != '1' ">net8.0;net8.0-android</TargetFrameworks>
+    <TargetFramework Condition=" '$(CI_DONT_TARGET_ANDROID)' == '1' ">net8.0</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <RootNamespace>SDL</RootNamespace>
     <Nullable>enable</Nullable>

--- a/SDL3_mixer-CS/SDL3_mixer-CS.csproj
+++ b/SDL3_mixer-CS/SDL3_mixer-CS.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(CI_DONT_TARGET_ANDROID)' != '1' ">net8.0;net8.0-android</TargetFrameworks>
+    <TargetFramework Condition=" '$(CI_DONT_TARGET_ANDROID)' == '1' ">net8.0</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <RootNamespace>SDL</RootNamespace>
     <Nullable>enable</Nullable>

--- a/SDL3_ttf-CS/SDL3_ttf-CS.csproj
+++ b/SDL3_ttf-CS/SDL3_ttf-CS.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net8.0-android</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(CI_DONT_TARGET_ANDROID)' != '1' ">net8.0;net8.0-android</TargetFrameworks>
+    <TargetFramework Condition=" '$(CI_DONT_TARGET_ANDROID)' == '1' ">net8.0</TargetFramework>
     <SupportedOSPlatformVersion>21</SupportedOSPlatformVersion>
     <RootNamespace>SDL</RootNamespace>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Adds a simple workflow that builds all platforms' `.slnf` projects. The workflow file is modelled after [ppy/osu's](https://github.com/ppy/osu/blob/c26e669fc534ef2b292effa0e9aebb9dd714632c/.github/workflows/ci.yml#L107-L154).

This should be useful in preventing binding updates that don't compile (I'm sometimes too lazy to test or I think nothing will break), latest example in https://github.com/ppy/SDL3-CS/pull/248.

Working run: https://github.com/Susko3/SDL3-CS/actions/runs/17348650861
Same run after inducing a compile error: https://github.com/Susko3/SDL3-CS/actions/runs/17348699346

## Implementation details

To make desktop and iOS builds faster, the dotnet `android` workload is not installed. To prevent restore errors, `CI_DONT_TARGET_ANDROID=1` has been added to remove the `net8.0-android` target. I've tried many different workarounds to skip restoring android (specifying `--framework`, `--runtime`, `-p:TargetFrameworks=net8.0`, splitting the `restore` and `build` stages, etc.) and I've found this simple solution easiest to implement and test. Its simplicity makes it the most reliable option.

## In the future

We have SDL3-CS.Tests, but due to our two-step process of updating bindings and then native binaries, these tests might intermittently fail. It would be useful to have some basic tests, but the current ones are not written with CI in mind. It's not a priority anyways.