### PR TITLE
Fix libflac build by using windows-2022 for x86

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         platform:
           - { name: win-x64,     os: windows-latest,   flags: -A x64 }
-          - { name: win-x86,     os: windows-latest,   flags: -A Win32 }
+          - { name: win-x86,     os: windows-2022,     flags: -A Win32 }
           - { name: win-arm64,   os: windows-latest,   flags: -A ARM64 }
           - { name: linux-x64,   os: ubuntu-22.04,     flags: -GNinja, target_apt_arch: ":amd64" }
           - { name: linux-x86,   os: ubuntu-22.04,     flags: -GNinja -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DWAVPACK_ENABLE_ASM=OFF, target_apt_arch: ":i386" }


### PR DESCRIPTION
windows-latest runners updated from windows server 2022 to windows server 2025 and this broke our win-x86 build. I don't really want to investigate further, so I've just rolled-back the winx-86 build to windows server 2022.

Failing run on master: https://github.com/Susko3/SDL3-CS/actions/runs/17860376465/job/50789284984
Working run with this PR's changes: https://github.com/Susko3/SDL3-CS/actions/runs/17860427227/job/50789477421

```cs
Build FAILED.

"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\build\ALL_BUILD.vcxproj" (default target) (1) ->
"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\build\SDL3_mixer-shared.vcxproj" (default target) (3) ->
"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\build\external\flac-build\src\libFLAC\FLAC.vcxproj" (default target) (4) ->
"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\build\external\flac-build\src\libFLAC\ia32\FLAC-asm.vcxproj" (default target) (5) ->
(_NASM target) -> 
  C:\Program Files\CMake\share\cmake-3.31\Templates\MSBuild\nasm.targets(33,5): error MSB3721: The command ""C:/Strawberry/c/bin/nasm.exe" -o "FLAC-asm.dir\Release\cpu_asm.obj" -fwin32 -I"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\external\flac\src\libFLAC\ia32\\" -I"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\external\flac\include\\" -I"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\build\external\flac-build\\" -I"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\external\flac\src\libFLAC\ia32\\" -D"CMAKE_INTDIR="Release"" -dOBJ_FORMAT_win32 /wd4267 /wd4996 "D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\external\flac\src\libFLAC\ia32\cpu_asm.nasm"" exited with code 1. [D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\build\external\flac-build\src\libFLAC\ia32\FLAC-asm.vcxproj]
```

The last line is (with word-wrap):
`C:\Program Files\CMake\share\cmake-3.31\Templates\MSBuild\nasm.targets(33,5): error MSB3721: The command ""C:/Strawberry/c/bin/nasm.exe" -o "FLAC-asm.dir\Release\cpu_asm.obj" -fwin32 -I"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\external\flac\src\libFLAC\ia32\\" -I"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\external\flac\include\\" -I"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\build\external\flac-build\\" -I"D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\external\flac\src\libFLAC\ia32\\" -D"CMAKE_INTDIR="Release"" -dOBJ_FORMAT_win32 /wd4267 /wd4996 "D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\external\flac\src\libFLAC\ia32\cpu_asm.nasm"" exited with code 1. [D:\a\SDL3-CS\SDL3-CS\External\SDL_mixer\build\external\flac-build\src\libFLAC\ia32\FLAC-asm.vcxproj]`