### PR TITLE
Target API 21 in Android builds to fix them not working on older versions

### DIFF
--- a/External/build.sh
+++ b/External/build.sh
@@ -94,7 +94,7 @@ else
     export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$NDK_VER"
     export FLAGS="$FLAGS -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
                          -DANDROID_HOME=$ANDROID_HOME \
-                         -DANDROID_PLATFORM=21 \
+                         -DANDROID_PLATFORM=24 \
                          -DANDROID_ABI=$ANDROID_ABI \
                          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                          -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \

--- a/External/build.sh
+++ b/External/build.sh
@@ -94,7 +94,7 @@ else
     export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$NDK_VER"
     export FLAGS="$FLAGS -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
                          -DANDROID_HOME=$ANDROID_HOME \
-                         -DANDROID_PLATFORM=24 \
+                         -DANDROID_PLATFORM=21 \
                          -DANDROID_ABI=$ANDROID_ABI \
                          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                          -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \
@@ -152,6 +152,10 @@ run_cmake() {
     if [[ $BUILD_PLATFORM == 'Windows' && $LIB_NAME == 'SDL' ]]; then
         echo "Patching SDL to not include gameinput.h"
         sed -i 's/#include <gameinput.h>/#_include <gameinput.h>/g' CMakeLists.txt
+    fi
+
+    if [[ $BUILD_PLATFORM == 'Android' && $LIB_NAME == 'SDL_mixer' ]]; then
+        export FLAGS="${FLAGS/-DANDROID_PLATFORM=21/-DANDROID_PLATFORM=24}"
     fi
 
     rm -rf build

--- a/External/build.sh
+++ b/External/build.sh
@@ -84,7 +84,7 @@ if [[ $BUILD_PLATFORM != 'Android' ]]; then
             libdecor-0-dev$TARGET_APT_ARCH
     fi
 else
-    if [[ -z $ANDROID_HOME || -z $NDK_VER || -z $PLATFORM_VER || -z $ANDROID_ABI ]]; then
+    if [[ -z $ANDROID_HOME || -z $NDK_VER || -z $ANDROID_ABI ]]; then
         echo "One or more required environment variables are not defined."
         exit 1
     fi
@@ -94,7 +94,7 @@ else
     export ANDROID_NDK_HOME="$ANDROID_HOME/ndk/$NDK_VER"
     export FLAGS="$FLAGS -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK_HOME/build/cmake/android.toolchain.cmake \
                          -DANDROID_HOME=$ANDROID_HOME \
-                         -DANDROID_PLATFORM=$PLATFORM_VER \
+                         -DANDROID_PLATFORM=21 \
                          -DANDROID_ABI=$ANDROID_ABI \
                          -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
                          -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=BOTH \

--- a/External/build.sh
+++ b/External/build.sh
@@ -154,6 +154,7 @@ run_cmake() {
         sed -i 's/#include <gameinput.h>/#_include <gameinput.h>/g' CMakeLists.txt
     fi
 
+    # Change the minumum Android API level for SDL_mixer to API 24 as opusfile and libflac fail to build on lower versions.
     if [[ $BUILD_PLATFORM == 'Android' && $LIB_NAME == 'SDL_mixer' ]]; then
         export FLAGS="${FLAGS/-DANDROID_PLATFORM=21/-DANDROID_PLATFORM=24}"
     fi

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Contributions to keep the bindings up-to-date with upstream changes are welcome.
 | `SDL3-CS`       | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
 | `SDL3_image-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
 | `SDL3_ttf-CS`   | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
-| `SDL3_mixer-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
+| `SDL3_mixer-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | API 24+   |
 
 ## Generating bindings
 

--- a/README_nuget.md
+++ b/README_nuget.md
@@ -16,4 +16,4 @@ Contributions to keep the bindings up-to-date with upstream changes are welcome.
 | `SDL3-CS`       | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
 | `SDL3_image-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
 | `SDL3_ttf-CS`   | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
-| `SDL3_mixer-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
+| `SDL3_mixer-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | API 24+   |


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/34992

This change also invalidates upstream issues https://github.com/libsdl-org/SDL/issues/13793 and https://github.com/libsdl-org/SDL/issues/13977. We were building SDL3 wrong, upstream was not at fault here.

Successful run: https://github.com/Susko3/SDL3-CS/actions/runs/17860790283 (ignore unrelated win-x86 failures).

---

The [`ANDROID_PLATFORM`](https://developer.android.com/ndk/guides/cmake#android_platform) CMake argument specifies the minimum API that the compiled libraries will support, we were setting it to API 35, meaning anything older than Android 15 was technically unsupported. This PR correctly sets it to API 21 (the minimum version supported by SDL and advertised by osu-framework).

SDL_mixer targets API 24 because opusfile and libflac were broken on 32-bit (arm and x86), see fb36b24faf88593c1f82cee82566d72ada8835d9 for more info.