### PR TITLE
Add missing Linux libraries to build.sh

### DIFF
--- a/External/build.sh
+++ b/External/build.sh
@@ -81,7 +81,9 @@ if [[ $BUILD_PLATFORM != 'Android' ]]; then
             libgbm-dev$TARGET_APT_ARCH \
             libpulse-dev$TARGET_APT_ARCH \
             libpipewire-0.3-dev$TARGET_APT_ARCH \
-            libdecor-0-dev$TARGET_APT_ARCH
+            libdecor-0-dev$TARGET_APT_ARCH \
+            libjack-dev$TARGET_APT_ARCH \
+            libusb-1.0-0-dev$TARGET_APT_ARCH
     fi
 else
     if [[ -z $ANDROID_HOME || -z $NDK_VER || -z $ANDROID_ABI ]]; then


### PR DESCRIPTION
Add Linux libraries libjack and libusb to build.sh. The latter fixes an issue with the Nintendo Switch 2 Pro Controller, as outlined here: https://github.com/Ryubing/Issues/issues/318.