### PR TITLE
Build using static MSVC runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { name: win-x64,     os: windows-latest,   flags: -A x64 }
-          - { name: win-x86,     os: windows-2022,     flags: -A Win32 }
-          - { name: win-arm64,   os: windows-latest,   flags: -A ARM64 }
+          - { name: win-x64,     os: windows-latest,   flags: -A x64 -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded }
+          - { name: win-x86,     os: windows-2022,     flags: -A Win32 -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded }
+          - { name: win-arm64,   os: windows-latest,   flags: -A ARM64 -DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded }
           - { name: linux-x64,   os: ubuntu-22.04,     flags: -GNinja, target_apt_arch: ":amd64" }
           - { name: linux-x86,   os: ubuntu-22.04,     flags: -GNinja -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DWAVPACK_ENABLE_ASM=OFF, target_apt_arch: ":i386" }
           - { name: linux-arm64, os: ubuntu-22.04-arm, flags: -GNinja, target_apt_arch: ":arm64", container: "arm64v8/ubuntu:22.04" }


### PR DESCRIPTION
We had [reports](https://discord.com/channels/188630481301012481/1097318920991559880/1503300872812236902) that osu! fails to start up on Windows 10 with error:

```
2026-05-10 10:56:38 [verbose]: System.DllNotFoundException: Unable to load DLL 'SDL3' or one of its dependencies: Не найден указанный модуль. (0x8007007E)
```

The user resolved this by installing VC++ Redistributable packages.

Looking into it further, upstream SDL statically links against MSVC to get around this issue: https://github.com/libsdl-org/SDL/blob/f30ec9940af42c08466a36e42fe6d5847f7c124f/build-scripts/build-release.py#L1314-L1317. We should do the same.

Have already tested this to work on a target system.