### PR TITLE
Update SDL to latest main

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,19 @@ Contributions to keep the bindings up-to-date with upstream changes are welcome.
 | `SDL3_ttf-CS`   | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | &check;   |
 | `SDL3_mixer-CS` | &check;   | &check;   | &check;     | &check;     | &check;   | &check;     | &check;     | &check;       | &check;     | &check; | API 24+   |
 
-## Generating bindings
+## How to update SDL
 
-Bindings are generated via the provided Dockerfile:
-
-```sh
-docker build -t 'sdl-gen' .
-docker run --rm -v .:/app -w /app -it sdl-gen
-```
+1. Ensure all submodules are correctly initialised:
+   ```sh
+   git submodule update --init --recursive
+   ```
+2. Check out submodules at new desired upstream commits.
+3. Regenerate C# bindings via:
+   ```sh
+   docker build -t 'sdl-gen' .
+   docker run --rm -v .:/app -w /app -it sdl-gen
+   ```
+4. Run the "Build Native" (`.github/workflows/build.yml`) workflow to generate platform binaries.
 
 ## License
 

--- a/SDL3-CS/SDL3/ClangSharp/SDL_events.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_events.g.cs
@@ -147,6 +147,7 @@ namespace SDL
         SDL_EVENT_CAMERA_DEVICE_REMOVED,
         SDL_EVENT_CAMERA_DEVICE_APPROVED,
         SDL_EVENT_CAMERA_DEVICE_DENIED,
+        SDL_EVENT_NOTIFICATION_ACTION_INVOKED = 0x1500,
         SDL_EVENT_RENDER_TARGETS_RESET = 0x2000,
         SDL_EVENT_RENDER_DEVICE_RESET,
         SDL_EVENT_RENDER_DEVICE_LOST,
@@ -752,6 +753,23 @@ namespace SDL
         public SDL_CameraID which;
     }
 
+    public unsafe partial struct SDL_NotificationEvent
+    {
+        public SDL_EventType type;
+
+        [NativeTypeName("Uint32")]
+        public uint reserved;
+
+        [NativeTypeName("Uint64")]
+        public ulong timestamp;
+
+        [NativeTypeName("SDL_NotificationID")]
+        public uint which;
+
+        [NativeTypeName("const char *")]
+        public byte* action_id;
+    }
+
     public partial struct SDL_RenderEvent
     {
         public SDL_EventType type;
@@ -805,6 +823,14 @@ namespace SDL
         public float scale;
 
         public SDL_WindowID windowID;
+
+        public float span_x;
+
+        public float span_y;
+
+        public float focus_x;
+
+        public float focus_y;
     }
 
     public partial struct SDL_PenProximityEvent
@@ -1147,6 +1173,9 @@ namespace SDL
 
         [FieldOffset(0)]
         public SDL_ClipboardEvent clipboard;
+
+        [FieldOffset(0)]
+        public SDL_NotificationEvent notification;
 
         [FieldOffset(0)]
         [NativeTypeName("Uint8[128]")]

--- a/SDL3-CS/SDL3/ClangSharp/SDL_hints.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_hints.g.cs
@@ -196,6 +196,9 @@ namespace SDL
         [NativeTypeName("#define SDL_HINT_ENABLE_SCREEN_KEYBOARD \"SDL_ENABLE_SCREEN_KEYBOARD\"")]
         public static ReadOnlySpan<byte> SDL_HINT_ENABLE_SCREEN_KEYBOARD => "SDL_ENABLE_SCREEN_KEYBOARD"u8;
 
+        [NativeTypeName("#define SDL_HINT_ENABLE_STEAM_SCREEN_KEYBOARD \"SDL_ENABLE_STEAM_SCREEN_KEYBOARD\"")]
+        public static ReadOnlySpan<byte> SDL_HINT_ENABLE_STEAM_SCREEN_KEYBOARD => "SDL_ENABLE_STEAM_SCREEN_KEYBOARD"u8;
+
         [NativeTypeName("#define SDL_HINT_EVDEV_DEVICES \"SDL_EVDEV_DEVICES\"")]
         public static ReadOnlySpan<byte> SDL_HINT_EVDEV_DEVICES => "SDL_EVDEV_DEVICES"u8;
 

--- a/SDL3-CS/SDL3/ClangSharp/SDL_stdinc.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_stdinc.g.cs
@@ -82,6 +82,10 @@ namespace SDL
         public static extern IntPtr SDL_aligned_alloc([NativeTypeName("size_t")] nuint alignment, [NativeTypeName("size_t")] nuint size);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("void*")]
+        public static extern IntPtr SDL_aligned_alloc_zero([NativeTypeName("size_t")] nuint alignment, [NativeTypeName("size_t")] nuint size);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern void SDL_aligned_free([NativeTypeName("void*")] IntPtr mem);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -259,6 +263,18 @@ namespace SDL
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("long")]
         public static extern int SDL_wcstol([NativeTypeName("const wchar_t *")] IntPtr str, [NativeTypeName("wchar_t **")] IntPtr* endp, int @base);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("unsigned long")]
+        public static extern uint SDL_wcstoul([NativeTypeName("const wchar_t *")] IntPtr str, [NativeTypeName("wchar_t **")] IntPtr* endp, int @base);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("long long")]
+        public static extern long SDL_wcstoll([NativeTypeName("const wchar_t *")] IntPtr str, [NativeTypeName("wchar_t **")] IntPtr* endp, int @base);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("unsigned long long")]
+        public static extern ulong SDL_wcstoull([NativeTypeName("const wchar_t *")] IntPtr str, [NativeTypeName("wchar_t **")] IntPtr* endp, int @base);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("size_t")]

--- a/SDL3-CS/SDL3/ClangSharp/SDL_system.Linux.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_system.Linux.g.cs
@@ -23,6 +23,7 @@
   3. This notice may not be removed or altered from any source distribution.
 */
 
+using System;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 
@@ -39,5 +40,19 @@ namespace SDL
         [return: NativeTypeName("bool")]
         [SupportedOSPlatform("Linux")]
         public static extern SDLBool SDL_SetLinuxThreadPriorityAndPolicy([NativeTypeName("Sint64")] long threadID, int sdlPriority, int schedPolicy);
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        [return: NativeTypeName("bool")]
+        [SupportedOSPlatform("Linux")]
+        public static extern SDLBool SDL_IsUbuntuTouch();
+
+        [NativeTypeName("#define SDL_PROP_GLOBAL_SYSTEM_UBUNTU_TOUCH_APPID_STRING \"SDL.system.ubuntu_touch.appid\"")]
+        public static ReadOnlySpan<byte> SDL_PROP_GLOBAL_SYSTEM_UBUNTU_TOUCH_APPID_STRING => "SDL.system.ubuntu_touch.appid"u8;
+
+        [NativeTypeName("#define SDL_PROP_GLOBAL_SYSTEM_UBUNTU_TOUCH_HOOK_STRING \"SDL.system.ubuntu_touch.hook\"")]
+        public static ReadOnlySpan<byte> SDL_PROP_GLOBAL_SYSTEM_UBUNTU_TOUCH_HOOK_STRING => "SDL.system.ubuntu_touch.hook"u8;
+
+        [NativeTypeName("#define SDL_PROP_GLOBAL_SYSTEM_UBUNTU_TOUCH_APP_VERSION_STRING \"SDL.system.ubuntu_touch.app_version\"")]
+        public static ReadOnlySpan<byte> SDL_PROP_GLOBAL_SYSTEM_UBUNTU_TOUCH_APP_VERSION_STRING => "SDL.system.ubuntu_touch.app_version"u8;
     }
 }

--- a/SDL3-CS/SDL3/ClangSharp/SDL_system.g.cs
+++ b/SDL3-CS/SDL3/ClangSharp/SDL_system.g.cs
@@ -28,6 +28,21 @@ using System.Runtime.InteropServices;
 
 namespace SDL
 {
+    public enum SDL_FormFactor
+    {
+        SDL_FORMFACTOR_UNKNOWN = 0,
+        SDL_FORMFACTOR_DESKTOP,
+        SDL_FORMFACTOR_LAPTOP,
+        SDL_FORMFACTOR_PHONE,
+        SDL_FORMFACTOR_TABLET,
+        SDL_FORMFACTOR_CONSOLE,
+        SDL_FORMFACTOR_HANDHELD,
+        SDL_FORMFACTOR_WATCH,
+        SDL_FORMFACTOR_TV,
+        SDL_FORMFACTOR_HEADSET,
+        SDL_FORMFACTOR_CAR,
+    }
+
     public enum SDL_Sandbox
     {
         SDL_SANDBOX_NONE = 0,
@@ -35,6 +50,7 @@ namespace SDL
         SDL_SANDBOX_FLATPAK,
         SDL_SANDBOX_SNAP,
         SDL_SANDBOX_MACOS,
+        SDL_SANDBOX_LOMIRI,
     }
 
     public static unsafe partial class SDL3
@@ -53,6 +69,13 @@ namespace SDL
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("bool")]
         public static extern SDLBool SDL_IsTV();
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
+        public static extern SDL_FormFactor SDL_GetDeviceFormFactor();
+
+        [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GetDeviceFormFactorName", ExactSpelling = true)]
+        [return: NativeTypeName("const char *")]
+        public static extern byte* Unsafe_SDL_GetDeviceFormFactorName(SDL_FormFactor form_factor);
 
         [DllImport("SDL3", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         public static extern SDL_Sandbox SDL_GetSandbox();

--- a/SDL3-CS/SDL3/SDL_events.cs
+++ b/SDL3-CS/SDL3/SDL_events.cs
@@ -38,6 +38,11 @@ namespace SDL
         public string? GetData() => SDL3.PtrToStringUTF8(data);
     }
 
+    public unsafe partial struct SDL_NotificationEvent
+    {
+        public string? GetActionId() => SDL3.PtrToStringUTF8(action_id);
+    }
+
     public partial struct SDL_MouseButtonEvent
     {
         public SDLButton Button => (SDLButton)button;

--- a/SDL3-CS/generate_bindings.py
+++ b/SDL3-CS/generate_bindings.py
@@ -329,7 +329,7 @@ def run_clangsharp(command, header: Header):
 
 
 # regex for ClangSharp-generated SDL functions and enums
-generated_symbol_regex = re.compile(r"public (enum|static extern \w+\**) (SDL_\w+)")
+generated_symbol_regex = re.compile(rf"public (enum|static extern \w+\**) (?:{unsafe_prefix})?(SDL_\w+)")
 
 
 def get_generated_symbols(file):


### PR DESCRIPTION
## [Add unambiguous instructions how to update SDL](https://github.com/ppy/SDL3-CS/commit/306621d07f02d1220c6e52356343504a0c96e848)

There were none other than a vague hint at half of it in README.

## [Update SDL submodule to latest `main`](https://github.com/ppy/SDL3-CS/commit/b320f5b16c1e0ef1cc50497fdf06c5de5948fa66)

Doing this to include https://github.com/libsdl-org/SDL/pull/15687, with the hopes of it fixing recent reports of regressing performance and/or fullscreen behaviours (https://github.com/ppy/osu/issues/38121, https://github.com/ppy/osu/issues/38125). I was able to reproduce the part of it to do with the system-level framerate no longer being respected, and updating to latest `main` does appear to have fixed that issue.

I will say that I think that the established practice of pointing the SDL submodule at wherever upstream `main` is at time of last person touching this repository contributes a lot to our collective chagrin related to random SDL breakage, and that we should start pointing the submodule at actual tagged stable releases. I almost did that here, but doing so resulted in some code getting removed from the generated bindings, and I did not want to explain myself further.

## [Fix binding generator emitting duplicate symbols for functions marked unsafe](https://github.com/ppy/SDL3-CS/commit/e8503f5f2a6c27487ca89dbe1439640a2f4f7176)

`SDL_system.h` now contains a

```c
extern SDL_DECLSPEC const char* SDLCALL SDL_GetDeviceFormFactorName(SDL_FormFactor form_factor);
```

function which gets marked with the `Unsafe_` prefix due to returning a string pointer via a ClangSharp remap.

`generated_symbol_regex` does not match methods marked `Unsafe_`. This led to `generate_platform_specific_headers()` not excluding that method, therefore emitting one extra copy of it per platform, thus causing binding compilation failures.

This adds the prefix into the regex so that relevant methods can match.

Of note, the `Unsafe_` prefix is placed in a *non-capturing group*, and that non-capturing group *is not inside the 2nd group* that `get_generated_symbols()` uses to retrieve the function name. This is because the output of `get_generated_symbols()` gets passed *back to ClangSharp*, which means that the *original function name* has to be retrieved for the exclusion of platform-agnostic marked-unsafe functions to actually work.